### PR TITLE
feat: implement dev mode in Spiral and add Test algorithm

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -3,6 +3,10 @@ import './src/utils/roundRect.js';
 
 import MusicPlayer from './src/MusicPlayer.js';
 import Spiral from './src/Spiral.js';
+import Test from './src/algos/Test.js';
 
-new Spiral();
+const devMode = false;
+const devAlgorithmClass = Test;
+
+new Spiral({ devMode, devAlgorithmClass });
 new MusicPlayer();

--- a/scripts/generate-algorithm-registry.mjs
+++ b/scripts/generate-algorithm-registry.mjs
@@ -47,7 +47,8 @@ const run = async () => {
     const files = entries
         .filter((entry) => entry.isFile() && entry.name.endsWith('.js'))
         .map((entry) => entry.name)
-        .sort((a, b) => a.localeCompare(b));
+        .sort((a, b) => a.localeCompare(b))
+        .filter((filename) => filename !== 'Test.js');
 
     if (files.length === 0) {
         throw new Error(

--- a/src/Spiral.js
+++ b/src/Spiral.js
@@ -3,12 +3,15 @@ import AlgorithmLoader from './AlgorithmLoader.js';
 import { random, randomColor } from './utils/randomUtils.js';
 
 export default class Spiral {
-    constructor() {
+    constructor(options = {}) {
         // Setup canvas
         this.canvas = document.querySelector('#canvas');
         this.ctx = this.canvas.getContext('2d');
         this.w = this.canvas.width = window.innerWidth;
         this.h = this.canvas.height = window.innerHeight;
+
+        this.devMode = options.devMode === true;
+        this.devAlgorithmClass = options.devAlgorithmClass || null;
 
         // Algorithm loader instance
         this.algorithmLoader = new AlgorithmLoader(this.ctx, this.w, this.h);
@@ -56,7 +59,7 @@ export default class Spiral {
         }, 20000);
 
         // make algorithms auto-change if not in manual mode
-        if (!this.manual) {
+        if (!this.manual && !this.devMode) {
             this.regen = setInterval(() => {
                 this.canvas.click();
             }, this.autoChange * 1000);
@@ -88,22 +91,27 @@ export default class Spiral {
         window.addEventListener('keyup', (e) => {
             switch (e.code) {
                 case 'Space':
-                    this.canvas.click();
+                    if (!this.devMode) {
+                        this.canvas.click();
+                    }
                     break;
                 case 'KeyF':
                     document.body.requestFullscreen();
                     break;
                 case 'KeyI':
+                    if (this.devMode) break;
                     this.autoChange += 10;
                     if (this.autoChange > 300) this.autoChange = 300;
                     this.displayMessage(`Auto-change: ${this.autoChange}secs`);
                     break;
                 case 'KeyD':
+                    if (this.devMode) break;
                     this.autoChange -= 10;
                     if (this.autoChange < 10) this.autoChange = 10;
                     this.displayMessage(`Auto-change: ${this.autoChange}secs`);
                     break;
                 case 'KeyM':
+                    if (this.devMode) break;
                     this.manual = !this.manual;
                     this.displayMessage(
                         this.manual ? 'Manual mode' : 'Auto mode',
@@ -130,6 +138,7 @@ export default class Spiral {
 
         // on canvas click, generate a new spiral
         this.canvas.addEventListener('click', () => {
+            if (this.devMode) return;
             this.ctx.save();
             // clear any timers
             this.stopCurrentAlgorithm();
@@ -188,7 +197,18 @@ export default class Spiral {
         this.ctx.save();
         // clear any timers
         this.stopCurrentAlgorithm();
-        const AlgorithmClass = this.algorithmChooser.getRandomAlgorithm();
+        let AlgorithmClass = this.algorithmChooser.getRandomAlgorithm();
+        if (this.devMode) {
+            if (
+                !this.devAlgorithmClass ||
+                typeof this.devAlgorithmClass !== 'function'
+            ) {
+                throw new Error(
+                    'Dev mode enabled but no devAlgorithmClass provided.',
+                );
+            }
+            AlgorithmClass = this.devAlgorithmClass;
+        }
         this.currentAlgorithm = new AlgorithmClass(this.ctx, this.w, this.h);
         // display algorithm name
         this.displayAlgorithmName(this.currentAlgorithm.name);

--- a/src/algos/Test.js
+++ b/src/algos/Test.js
@@ -1,0 +1,43 @@
+import AL from '../AlgorithmLoader.js';
+
+export default class Test extends AL {
+    constructor(ctx, w, h) {
+        super(ctx, w, h);
+
+        this.name = 'Test';
+
+        this.initializeProperties();
+        this.setupDrawingStyles();
+
+        this.interval = requestAnimationFrame(this.draw);
+    }
+
+    initializeProperties() {
+        this.rotation = AL.random(1, 100);
+        this.x = AL.random(0, this.w);
+        this.y = AL.random(0, this.h);
+        this.width = AL.random(10, 200);
+        this.height = AL.random(10, 200);
+    }
+
+    setupDrawingStyles() {
+        this.ctx.fillStyle = AL.randomColor();
+    }
+
+    draw() {
+        if (this.t % this.speed === 0) {
+            this.ctx.fillRect(this.x, this.y, this.width, this.height);
+        }
+
+        this.rotateCanvasRadians(this.rotation);
+
+        this.t++;
+
+        if (this.t % (this.speed * 200) === 0) {
+            this.initializeProperties();
+            this.setupDrawingStyles();
+        }
+
+        requestAnimationFrame(this.draw);
+    }
+}


### PR DESCRIPTION
This pull request introduces a development mode to the `Spiral` visualization app, allowing developers to run a specific algorithm (`Test`) for debugging or testing purposes. The changes add a new algorithm (`Test`), modify the app's initialization to support dev mode, and ensure dev mode disables auto-changing and manual controls. The algorithm registry script is also updated to exclude the `Test` algorithm from production builds.

**Development mode support in Spiral:**

* Added `devMode` and `devAlgorithmClass` options to the `Spiral` constructor, enabling the app to run a specified algorithm in development mode and disabling auto-change/manual controls when enabled. (`renderer.js`, `src/Spiral.js`) [[1]](diffhunk://#diff-8a8d77cf15b2eaf50ec617c3603313fe363eaef34d8eb3c20ce12b607da55f04R6-R11) [[2]](diffhunk://#diff-719562065687833f7cd3331f53d4e42226a328e9e3e4a6e7635d82f0944b99b5L6-R15) [[3]](diffhunk://#diff-719562065687833f7cd3331f53d4e42226a328e9e3e4a6e7635d82f0944b99b5L59-R62) [[4]](diffhunk://#diff-719562065687833f7cd3331f53d4e42226a328e9e3e4a6e7635d82f0944b99b5R94-R114) [[5]](diffhunk://#diff-719562065687833f7cd3331f53d4e42226a328e9e3e4a6e7635d82f0944b99b5R141) [[6]](diffhunk://#diff-719562065687833f7cd3331f53d4e42226a328e9e3e4a6e7635d82f0944b99b5L191-R211)

**Algorithm registry improvements:**

* Updated `scripts/generate-algorithm-registry.mjs` to exclude `Test.js` from the registry, preventing the development algorithm from appearing in production builds.

**New development algorithm:**

* Added a new `Test` algorithm in `src/algos/Test.js` for development and debugging, which draws random rectangles and rotates the canvas.