### PR TITLE
feat: add Web Audio frequency analyser for audio-reactive visualizations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,7 @@ src/
     math.js          norm, lerp, map, clamp, distance, collision, deg↔rad, randomRange, bezier
     randomUtils.js   random(min, max), randomColor() — used by renderer.js and Spiral.js
     roundRect.js     Side-effect polyfill — patches CanvasRenderingContext2D prototype
+    FrequencyAnalyser.js  Web Audio API wrapper — splits FFT into configurable bands (default 5)
 assets/
   js/gsap.min.js     GSAP library (global)
   fonts/             Custom font files
@@ -74,21 +75,21 @@ assets/
 
 ## File Structure Map
 
-| Path                      | Purpose                                                               |
-| ------------------------- | --------------------------------------------------------------------- |
-| `main.js`                 | Electron main process entry                                           |
-| `preload.js`              | Context bridge, version injection                                     |
-| `renderer.js`             | Renderer entry: imports polyfills, Spiral + MusicPlayer init          |
-| `index.html`              | DOM structure: canvas, HUD, player controls                           |
-| `style.css`               | All styles                                                            |
-| `src/Spiral.js`           | Core orchestrator                                                     |
-| `src/MusicPlayer.js`      | Audio playback, playlist, progress bar, P-key toggle                  |
-| `src/AlgorithmChooser.js` | Algorithm registry and random picker                                  |
-| `src/AlgorithmLoader.js`  | Base class for algorithms                                             |
-| `src/algos/*.js`          | Individual algorithm classes (142 files)                              |
-| `src/utils/*.js`          | Shared utilities (Vector, Particle, math, random, roundRect polyfill) |
-| `assets/js/`              | GSAP (loaded globally, not via npm)                                   |
-| `assets/fonts/`           | Custom font files                                                     |
+| Path                      | Purpose                                                                                  |
+| ------------------------- | ---------------------------------------------------------------------------------------- |
+| `main.js`                 | Electron main process entry                                                              |
+| `preload.js`              | Context bridge, version injection                                                        |
+| `renderer.js`             | Renderer entry: imports polyfills, Spiral + MusicPlayer init                             |
+| `index.html`              | DOM structure: canvas, HUD, player controls                                              |
+| `style.css`               | All styles                                                                               |
+| `src/Spiral.js`           | Core orchestrator                                                                        |
+| `src/MusicPlayer.js`      | Audio playback, playlist, progress bar, P-key toggle                                     |
+| `src/AlgorithmChooser.js` | Algorithm registry and random picker                                                     |
+| `src/AlgorithmLoader.js`  | Base class for algorithms                                                                |
+| `src/algos/*.js`          | Individual algorithm classes (142 files)                                                 |
+| `src/utils/*.js`          | Shared utilities (Vector, Particle, math, random, roundRect polyfill, FrequencyAnalyser) |
+| `assets/js/`              | GSAP (loaded globally, not via npm)                                                      |
+| `assets/fonts/`           | Custom font files                                                                        |
 
 ## Code Conventions
 
@@ -119,6 +120,25 @@ assets/
 - The draw loop uses `requestAnimationFrame` — cancelled via `stop()` in
   `AlgorithmLoader`
 
+## Frequency Analyser
+
+- `FrequencyAnalyser` (`src/utils/FrequencyAnalyser.js`) wraps the Web Audio API
+  to provide real-time frequency data from the `<audio>` element
+- Audio graph: `MediaElementAudioSourceNode` → `AnalyserNode` →
+  `AudioContext.destination` (audio still plays through speakers)
+- `createMediaElementSource` can only be called **once** per `<audio>` element —
+  the analyser is created once in `renderer.js`
+- Exposed as `AlgorithmLoader.frequencyAnalyser` (static property, same pattern
+  as `AlgorithmLoader.gsap`)
+- `getBands()` returns a plain `Array` of normalised 0–1 values; band count
+  defaults to 3 (low / mid / high) but is configurable via the `bandCount`
+  setter
+- `getRawData()` returns the full `Uint8Array` FFT buffer for advanced use
+- `AudioContext` starts suspended — `MusicPlayer.playTrack()` calls `resume()`
+  on the first user gesture
+- Algorithms opt in by calling `AlgorithmLoader.frequencyAnalyser?.getBands()`
+  inside their `draw()` loop; the call returns all zeros when nothing is playing
+
 ## Dependency Rules
 
 - **No new runtime dependencies** without explicit approval
@@ -142,6 +162,9 @@ assets/
   shortcuts
 - GSAP is **global** (`window.gsap`) from the vendored file — `AlgorithmLoader`
   exposes it as a static ref
+- `FrequencyAnalyser` is instantiated once in `renderer.js` —
+  `createMediaElementSource` throws if called twice on the same `<audio>`
+  element
 - No tests exist — when adding test tooling, there is no existing infrastructure
   to extend
 - The `AlgorithmLoader` constructor receives `(ctx, w, h)` — these are the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 <!-- Format: ## YYYY-MM-DD followed by one-liner entries. -->
 
+## 2026-02-08
+
+- feat: Add Web Audio frequency analyser for audio-reactive visualizations
+
 ## 2026-02-07
 
 - docs: Rewrite README for end users with friendly tone

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -155,13 +155,21 @@ gh pr create \
   --title "<TYPE>: <DESCRIPTION>" \
   --body "<Detailed description of changes>" \
   --head <branch-name> \
-  --base spiral2
+  --base spiral2 \
+  --label "<LABEL>" \
+  --assignee rogerio-romao
 ```
+
+**Rules:**
+
+- Always include `--assignee rogerio-romao`
+- Always include `--label` matching the issue label (e.g., `enhancement`, `bug`,
+  `documentation`)
 
 **Before submitting, I will:**
 
 - Show you the draft PR title and description
-- Ask if you want to add labels (e.g., `ready-to-merge`, `review-pending`)
+- Ask if you want to add extra labels (e.g., `ready-to-merge`, `review-pending`)
 - Ask for any additional context or notes
 - Confirm you're ready to merge before creating the PR
 

--- a/renderer.js
+++ b/renderer.js
@@ -2,10 +2,10 @@
 import './src/utils/roundRect.js';
 
 import AlgorithmLoader from './src/AlgorithmLoader.js';
-import FrequencyAnalyser from './src/utils/FrequencyAnalyser.js';
 import MusicPlayer from './src/MusicPlayer.js';
 import Spiral from './src/Spiral.js';
 import Test from './src/algos/Test.js';
+import FrequencyAnalyser from './src/utils/FrequencyAnalyser.js';
 
 const devMode = false;
 const devAlgorithmClass = Test;

--- a/renderer.js
+++ b/renderer.js
@@ -1,6 +1,8 @@
 // side effect import to patch the CanvasRenderingContext2D prototype with roundRect
 import './src/utils/roundRect.js';
 
+import AlgorithmLoader from './src/AlgorithmLoader.js';
+import FrequencyAnalyser from './src/utils/FrequencyAnalyser.js';
 import MusicPlayer from './src/MusicPlayer.js';
 import Spiral from './src/Spiral.js';
 import Test from './src/algos/Test.js';
@@ -10,3 +12,8 @@ const devAlgorithmClass = Test;
 
 new Spiral({ devMode, devAlgorithmClass });
 new MusicPlayer();
+
+// Wire up the frequency analyser so algorithms can read audio data.
+// Uses the same <audio> element that MusicPlayer controls.
+const audioElement = document.getElementById('audio');
+AlgorithmLoader.frequencyAnalyser = new FrequencyAnalyser(audioElement);

--- a/src/AlgorithmLoader.js
+++ b/src/AlgorithmLoader.js
@@ -20,6 +20,8 @@ export default class AlgorithmLoader {
 
     static gsap = gsap;
 
+    static frequencyAnalyser = null;
+
     static createVector(x, y) {
         return new Vector(x, y);
     }

--- a/src/MusicPlayer.js
+++ b/src/MusicPlayer.js
@@ -78,6 +78,7 @@ export default class MusicPlayer {
             this.isPlaying = true;
             this.playIcon.name = 'pause-outline';
             this._updatePlaylistStyle();
+            this._resumeAnalyser();
             this.audio.play();
         } else if (this.playlistEls) {
             this.isPlaying = false;
@@ -164,6 +165,19 @@ export default class MusicPlayer {
         [...this.playlistEls].forEach((el) => (el.style.color = '#555'));
         this.playlistEls[this.currentSong].style.color = 'orange';
         this.playlistEls[this.currentSong].scrollIntoView();
+    }
+
+    /**
+     * Resume the AudioContext used by the frequency analyser.
+     * Must be called from a user gesture to satisfy autoplay policy.
+     * Safe to call when no analyser is wired up.
+     */
+    _resumeAnalyser() {
+        // Dynamically import to avoid circular dependency —
+        // AlgorithmLoader is set up by renderer.js after MusicPlayer.
+        import('./AlgorithmLoader.js').then(({ default: AlgorithmLoader }) => {
+            AlgorithmLoader.frequencyAnalyser?.resume();
+        });
     }
 
     /** Toggle player visibility with the P key. */

--- a/src/utils/FrequencyAnalyser.js
+++ b/src/utils/FrequencyAnalyser.js
@@ -18,7 +18,10 @@ export default class FrequencyAnalyser {
      * @param {number}  [options.fftSize=2048] — FFT window size (power of 2).
      * @param {number}  [options.smoothing=0.8] — smoothingTimeConstant (0–1).
      */
-    constructor(audioElement, { bandCount = 3, fftSize = 2048, smoothing = 0.8 } = {}) {
+    constructor(
+        audioElement,
+        { bandCount = 5, fftSize = 2048, smoothing = 0.8 } = {},
+    ) {
         this._bandCount = bandCount;
 
         // Create the audio context and graph
@@ -79,9 +82,8 @@ export default class FrequencyAnalyser {
         for (let b = 0; b < this._bandCount; b++) {
             const start = b * binsPerBand;
             // Last band absorbs any remainder bins
-            const end = b === this._bandCount - 1
-                ? binCount
-                : start + binsPerBand;
+            const end =
+                b === this._bandCount - 1 ? binCount : start + binsPerBand;
 
             let sum = 0;
             for (let i = start; i < end; i++) {

--- a/src/utils/FrequencyAnalyser.js
+++ b/src/utils/FrequencyAnalyser.js
@@ -1,0 +1,117 @@
+/**
+ * FrequencyAnalyser — wraps the Web Audio API to provide real-time
+ * frequency band data from an HTMLAudioElement.
+ *
+ * Audio graph: MediaElementSource → AnalyserNode → AudioContext.destination
+ * (audio still plays through speakers).
+ *
+ * Usage:
+ *   const analyser = new FrequencyAnalyser(audioElement, { bandCount: 3 });
+ *   analyser.resume();          // call on user gesture
+ *   const bands = analyser.getBands(); // [0.72, 0.35, 0.11]  (0–1 normalised)
+ */
+export default class FrequencyAnalyser {
+    /**
+     * @param {HTMLAudioElement} audioElement — the <audio> element to analyse.
+     * @param {object}  [options]
+     * @param {number}  [options.bandCount=3]  — number of frequency bands.
+     * @param {number}  [options.fftSize=2048] — FFT window size (power of 2).
+     * @param {number}  [options.smoothing=0.8] — smoothingTimeConstant (0–1).
+     */
+    constructor(audioElement, { bandCount = 3, fftSize = 2048, smoothing = 0.8 } = {}) {
+        this._bandCount = bandCount;
+
+        // Create the audio context and graph
+        this._ctx = new (window.AudioContext || window.webkitAudioContext)();
+        this._analyser = this._ctx.createAnalyser();
+        this._analyser.fftSize = fftSize;
+        this._analyser.smoothingTimeConstant = smoothing;
+
+        // createMediaElementSource can only be called once per element
+        this._source = this._ctx.createMediaElementSource(audioElement);
+        this._source.connect(this._analyser);
+        this._analyser.connect(this._ctx.destination);
+
+        // Reusable buffer for frequency data
+        this._dataArray = new Uint8Array(this._analyser.frequencyBinCount);
+    }
+
+    /** Number of bands currently configured. */
+    get bandCount() {
+        return this._bandCount;
+    }
+
+    /**
+     * Update the number of frequency bands.
+     * @param {number} count — new band count (must be >= 1).
+     */
+    set bandCount(count) {
+        if (count >= 1) {
+            this._bandCount = Math.floor(count);
+        }
+    }
+
+    /**
+     * Resume the AudioContext — must be called from a user gesture
+     * (e.g. click/keypress) to satisfy browser autoplay policy.
+     * Subsequent calls are no-ops.
+     */
+    resume() {
+        if (this._ctx.state === 'suspended') {
+            this._ctx.resume();
+        }
+    }
+
+    /**
+     * Get the current frequency data split into `bandCount` bands,
+     * each normalised to 0–1.
+     *
+     * @returns {number[]} Array of length `bandCount` with values 0–1.
+     *   Returns all zeros when nothing is playing.
+     */
+    getBands() {
+        this._analyser.getByteFrequencyData(this._dataArray);
+
+        const binCount = this._dataArray.length;
+        const binsPerBand = Math.floor(binCount / this._bandCount);
+        const bands = new Array(this._bandCount);
+
+        for (let b = 0; b < this._bandCount; b++) {
+            const start = b * binsPerBand;
+            // Last band absorbs any remainder bins
+            const end = b === this._bandCount - 1
+                ? binCount
+                : start + binsPerBand;
+
+            let sum = 0;
+            for (let i = start; i < end; i++) {
+                sum += this._dataArray[i];
+            }
+            // Normalise: byte values are 0–255
+            bands[b] = sum / ((end - start) * 255);
+        }
+
+        return bands;
+    }
+
+    /**
+     * Get the raw byte frequency data (0–255 per bin).
+     * Useful for advanced visualisations that need full FFT resolution.
+     *
+     * @returns {Uint8Array} The internal data array (mutated on each call).
+     */
+    getRawData() {
+        this._analyser.getByteFrequencyData(this._dataArray);
+        return this._dataArray;
+    }
+
+    /** The underlying AnalyserNode, for advanced configuration. */
+    get analyserNode() {
+        return this._analyser;
+    }
+
+    /** The underlying AudioContext, for advanced use. */
+    get audioContext() {
+        return this._ctx;
+    }
+}


### PR DESCRIPTION
- New FrequencyAnalyser class in src/utils/ wrapping AudioContext + AnalyserNode
- Splits FFT data into configurable bands (default 3), normalised 0-1
- Exposed as AlgorithmLoader.frequencyAnalyser (static prop, like gsap)
- renderer.js wires instantiation; MusicPlayer resumes AudioContext on play
- Audio still routes through speakers via analyser -> destination
- Update WORKFLOW.md: PRs must include --assignee and --label

Closes #39