### PR TITLE
refactor: Consolidate FrequencyAnalyser and MusicPlayer under Spiral

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,9 +43,10 @@ No TypeScript. No bundler. No test framework. No linter/formatter config.
 main.js              Electron main process — creates BrowserWindow
 preload.js           Injects version info via contextBridge
 index.html           DOM: canvas, HUD overlay, help screen, music player UI
-renderer.js          Renderer entry — imports polyfills, instantiates Spiral + MusicPlayer
+renderer.js          Renderer entry — imports polyfills, instantiates Spiral
 src/
-  Spiral.js          Orchestrator — algorithm lifecycle, keyboard shortcuts, HUD, transitions
+  Spiral.js          Orchestrator — algorithm lifecycle, keyboard shortcuts, HUD, transitions,
+                       owns MusicPlayer and FrequencyAnalyser
   MusicPlayer.js     Audio playback, playlist management, progress bar, P-key toggle
   AlgorithmChooser.js  Static imports of all 142 algos, random selection (avoids last 50)
   AlgorithmLoader.js   Base class for all algorithms (draw loop, helpers, stop/start)
@@ -79,10 +80,10 @@ assets/
 | ------------------------- | ---------------------------------------------------------------------------------------- |
 | `main.js`                 | Electron main process entry                                                              |
 | `preload.js`              | Context bridge, version injection                                                        |
-| `renderer.js`             | Renderer entry: imports polyfills, Spiral + MusicPlayer init                             |
+| `renderer.js`             | Renderer entry: imports polyfills, instantiates Spiral                                   |
 | `index.html`              | DOM structure: canvas, HUD, player controls                                              |
 | `style.css`               | All styles                                                                               |
-| `src/Spiral.js`           | Core orchestrator                                                                        |
+| `src/Spiral.js`           | Core orchestrator — owns MusicPlayer and FrequencyAnalyser                               |
 | `src/MusicPlayer.js`      | Audio playback, playlist, progress bar, P-key toggle                                     |
 | `src/AlgorithmChooser.js` | Algorithm registry and random picker                                                     |
 | `src/AlgorithmLoader.js`  | Base class for algorithms                                                                |
@@ -127,15 +128,15 @@ assets/
 - Audio graph: `MediaElementAudioSourceNode` → `AnalyserNode` →
   `AudioContext.destination` (audio still plays through speakers)
 - `createMediaElementSource` can only be called **once** per `<audio>` element —
-  the analyser is created once in `renderer.js`
+  the analyser is created once in `Spiral.js` constructor
 - Exposed as `AlgorithmLoader.frequencyAnalyser` (static property, same pattern
-  as `AlgorithmLoader.gsap`)
+  as `AlgorithmLoader.gsap`) — set by `Spiral.js`
 - `getBands()` returns a plain `Array` of normalised 0–1 values; band count
   defaults to 3 (low / mid / high) but is configurable via the `bandCount`
   setter
 - `getRawData()` returns the full `Uint8Array` FFT buffer for advanced use
-- `AudioContext` starts suspended — `MusicPlayer.playTrack()` calls `resume()`
-  on the first user gesture
+- `AudioContext` starts suspended — `Spiral.js` listens for the `audio` element's
+  `play` event and calls `resume()` automatically
 - Algorithms opt in by calling `AlgorithmLoader.frequencyAnalyser?.getBands()`
   inside their `draw()` loop; the call returns all zeros when nothing is playing
 
@@ -162,7 +163,7 @@ assets/
   shortcuts
 - GSAP is **global** (`window.gsap`) from the vendored file — `AlgorithmLoader`
   exposes it as a static ref
-- `FrequencyAnalyser` is instantiated once in `renderer.js` —
+- `FrequencyAnalyser` is instantiated once in `Spiral.js` constructor —
   `createMediaElementSource` throws if called twice on the same `<audio>`
   element
 - No tests exist — when adding test tooling, there is no existing infrastructure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 <!-- Format: ## YYYY-MM-DD followed by one-liner entries. -->
 
+## 2026-02-10
+
+- refactor: Consolidate FrequencyAnalyser and MusicPlayer ownership under Spiral
+
 ## 2026-02-08
 
 - feat: Add Web Audio frequency analyser for audio-reactive visualizations

--- a/renderer.js
+++ b/renderer.js
@@ -1,19 +1,10 @@
 // side effect import to patch the CanvasRenderingContext2D prototype with roundRect
 import './src/utils/roundRect.js';
 
-import AlgorithmLoader from './src/AlgorithmLoader.js';
-import MusicPlayer from './src/MusicPlayer.js';
 import Spiral from './src/Spiral.js';
 import Test from './src/algos/Test.js';
-import FrequencyAnalyser from './src/utils/FrequencyAnalyser.js';
 
 const devMode = true;
 const devAlgorithmClass = Test;
 
 new Spiral({ devMode, devAlgorithmClass });
-new MusicPlayer();
-
-// Wire up the frequency analyser so algorithms can read audio data.
-// Uses the same <audio> element that MusicPlayer controls.
-const audioElement = document.getElementById('audio');
-AlgorithmLoader.frequencyAnalyser = new FrequencyAnalyser(audioElement);

--- a/src/MusicPlayer.js
+++ b/src/MusicPlayer.js
@@ -78,7 +78,6 @@ export default class MusicPlayer {
             this.isPlaying = true;
             this.playIcon.name = 'pause-outline';
             this._updatePlaylistStyle();
-            this._resumeAnalyser();
             this.audio.play();
         } else if (this.playlistEls) {
             this.isPlaying = false;
@@ -165,19 +164,6 @@ export default class MusicPlayer {
         [...this.playlistEls].forEach((el) => (el.style.color = '#555'));
         this.playlistEls[this.currentSong].style.color = 'orange';
         this.playlistEls[this.currentSong].scrollIntoView();
-    }
-
-    /**
-     * Resume the AudioContext used by the frequency analyser.
-     * Must be called from a user gesture to satisfy autoplay policy.
-     * Safe to call when no analyser is wired up.
-     */
-    _resumeAnalyser() {
-        // Dynamically import to avoid circular dependency —
-        // AlgorithmLoader is set up by renderer.js after MusicPlayer.
-        import('./AlgorithmLoader.js').then(({ default: AlgorithmLoader }) => {
-            AlgorithmLoader.frequencyAnalyser?.resume();
-        });
     }
 
     /** Toggle player visibility with the P key. */

--- a/src/Spiral.js
+++ b/src/Spiral.js
@@ -1,5 +1,7 @@
 import AlgorithmChooser from './AlgorithmChooser.js';
 import AlgorithmLoader from './AlgorithmLoader.js';
+import FrequencyAnalyser from './utils/FrequencyAnalyser.js';
+import MusicPlayer from './MusicPlayer.js';
 import { random, randomColor } from './utils/randomUtils.js';
 
 export default class Spiral {
@@ -21,6 +23,18 @@ export default class Spiral {
 
         // running algorithm instance
         this.currentAlgorithm = null;
+
+        // Music player — Spiral owns the player and wires up the analyser
+        this.musicPlayer = new MusicPlayer();
+
+        // Frequency analyser — connects to the audio element owned by MusicPlayer
+        this.frequencyAnalyser = new FrequencyAnalyser(this.musicPlayer.audio);
+        AlgorithmLoader.frequencyAnalyser = this.frequencyAnalyser;
+
+        // Resume AudioContext on any play event (covers play, next, prev)
+        this.musicPlayer.audio.addEventListener('play', () => {
+            this.frequencyAnalyser.resume();
+        });
 
         // Setup message display
         this.messageTimer = null;


### PR DESCRIPTION
## Changes

- Spiral now owns MusicPlayer and FrequencyAnalyser
- renderer.js simplified to polyfill + new Spiral() only
- MusicPlayer cleaned up: removed _resumeAnalyser and dynamic import hack
- Spiral listens for audio play event to resume AudioContext
- AlgorithmLoader.frequencyAnalyser set by Spiral constructor
- Updated AGENTS.md to reflect new ownership

## Issue

Closes #43

## Testing

- [x] Tested with pnpm start
- [x] No console errors
- [x] App launches and algorithms render normally

## Checklist

- [x] Code follows AGENTS.md conventions
- [x] CHANGELOG.md updated
- [x] Related files updated