### PR TITLE
perf: Defer MusicPlayer and FrequencyAnalyser instantiation to init()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 <!-- Format: ## YYYY-MM-DD followed by one-liner entries. -->
 
+## 2026-02-15
+
+- perf: Defer MusicPlayer and FrequencyAnalyser instantiation to init()
+
 ## 2026-02-10
 
 - refactor: Consolidate FrequencyAnalyser and MusicPlayer ownership under Spiral

--- a/src/Spiral.js
+++ b/src/Spiral.js
@@ -1,7 +1,7 @@
 import AlgorithmChooser from './AlgorithmChooser.js';
 import AlgorithmLoader from './AlgorithmLoader.js';
-import FrequencyAnalyser from './utils/FrequencyAnalyser.js';
 import MusicPlayer from './MusicPlayer.js';
+import FrequencyAnalyser from './utils/FrequencyAnalyser.js';
 import { random, randomColor } from './utils/randomUtils.js';
 
 export default class Spiral {
@@ -24,17 +24,9 @@ export default class Spiral {
         // running algorithm instance
         this.currentAlgorithm = null;
 
-        // Music player — Spiral owns the player and wires up the analyser
-        this.musicPlayer = new MusicPlayer();
-
-        // Frequency analyser — connects to the audio element owned by MusicPlayer
-        this.frequencyAnalyser = new FrequencyAnalyser(this.musicPlayer.audio);
-        AlgorithmLoader.frequencyAnalyser = this.frequencyAnalyser;
-
-        // Resume AudioContext on any play event (covers play, next, prev)
-        this.musicPlayer.audio.addEventListener('play', () => {
-            this.frequencyAnalyser.resume();
-        });
+        // Music player and frequency analyser — deferred to init()
+        this.musicPlayer = null;
+        this.frequencyAnalyser = null;
 
         // Setup message display
         this.messageTimer = null;
@@ -84,6 +76,19 @@ export default class Spiral {
 
         // trigger the first algorithm
         this.chooseAlgos();
+
+        // Music player — deferred from constructor so algorithm loading
+        // and first render are not blocked by audio subsystem setup
+        this.musicPlayer = new MusicPlayer();
+
+        // Frequency analyser — connects to the audio element owned by MusicPlayer
+        this.frequencyAnalyser = new FrequencyAnalyser(this.musicPlayer.audio);
+        AlgorithmLoader.frequencyAnalyser = this.frequencyAnalyser;
+
+        // Resume AudioContext on any play event (covers play, next, prev)
+        this.musicPlayer.audio.addEventListener('play', () => {
+            this.frequencyAnalyser.resume();
+        });
     }
 
     addEventListeners() {


### PR DESCRIPTION
## Changes

- Move MusicPlayer and FrequencyAnalyser instantiation from the Spiral constructor to the end of `init()`, after algorithm loading and first render trigger
- Add null placeholder declarations in constructor for clarity
- Audio subsystem setup no longer blocks startup — first algorithm renders before audio components are initialized

## Issue

Closes #49

## Testing

- [x] Tested with `pnpm start`
- [x] No console errors at startup
- [x] Code follows AGENTS.md conventions
- [x] CHANGELOG.md updated

## Checklist

- [x] Code follows [AGENTS.md](AGENTS.md) conventions
- [x] CHANGELOG.md updated
- [x] Related files updated (if applicable)