### PR TITLE
fix: Security hardening — CSP, preload contextBridge, dep cleanup, blob URL revocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 ## 2026-02-15
 
 - perf: Defer MusicPlayer and FrequencyAnalyser instantiation to init()
+- fix: Add Content Security Policy meta tag to index.html
+- fix: Move electron from dependencies to devDependencies
+- fix: Rewrite preload.js to use contextBridge, remove dead DOM references
+- fix: Add blob URL revocation in MusicPlayer to prevent memory leaks
 
 ## 2026-02-10
 

--- a/TODO.md
+++ b/TODO.md
@@ -71,7 +71,8 @@
   `session.defaultSession.webRequest.onHeadersReceived`. Restrict to `'self'`
   with exceptions for inline styles and the Ionicons CDN if still needed.
 
-- [ ] Add CSP to `index.html` or `main.js`
+- [x] Add CSP to `index.html` — added meta tag restricting to `'self'` with
+      `'unsafe-inline'` for styles and `blob:` for audio media
 
 ### 2.2 — Electron listed as runtime dependency
 
@@ -80,7 +81,7 @@
   This is against Electron best practices and would bloat packaging.
 - **Fix:** Move to `devDependencies`.
 
-- [ ] Move `electron` to `devDependencies` in `package.json`
+- [x] Move `electron` to `devDependencies` in `package.json`
 
 ### 2.3 — `preload.js` doesn't use `contextBridge`
 
@@ -91,8 +92,8 @@
   `index.html` — the code is dead.
 - **Fix:** Rewrite using `contextBridge` pattern. Remove dead DOM references.
 
-- [ ] Rewrite `preload.js` to use `contextBridge`
-- [ ] Remove references to nonexistent DOM IDs
+- [x] Rewrite `preload.js` to use `contextBridge`
+- [x] Remove references to nonexistent DOM IDs
 
 ### 2.4 — Blob URLs never revoked
 
@@ -103,7 +104,8 @@
 - **Fix:** Track blob URLs and revoke them when tracks are removed, replaced, or
   the playlist is cleared.
 
-- [ ] Add `URL.revokeObjectURL` cleanup in `MusicPlayer.js`
+- [x] Add `URL.revokeObjectURL` cleanup in `MusicPlayer.js` — blob URLs revoked
+      via `_revokeBlobUrls()` before each new playlist load
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -2,6 +2,10 @@
 <html>
     <head>
         <meta charset="UTF-8" />
+        <meta
+            http-equiv="Content-Security-Policy"
+            content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; media-src 'self' blob:; img-src 'self' data:; font-src 'self'"
+        />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="stylesheet" href="style.css" />
         <title>The Spiral</title>

--- a/package.json
+++ b/package.json
@@ -18,10 +18,8 @@
     "author": "Rogerio Romao",
     "license": "CC0-1.0",
     "devDependencies": {
+        "electron": "^33.2.1",
         "electron-packager": "^17.1.2"
-    },
-    "dependencies": {
-        "electron": "^33.2.1"
     },
     "type": "module",
     "packageManager": "pnpm@9.15.1+sha512.1acb565e6193efbebda772702950469150cf12bcc764262e7587e71d19dc98a423dff9536e57ea44c49bdf790ff694e83c27be5faa23d67e0c033b583be4bfcf"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,11 +7,10 @@ settings:
 importers:
 
   .:
-    dependencies:
+    devDependencies:
       electron:
         specifier: ^33.2.1
         version: 33.2.1
-    devDependencies:
       electron-packager:
         specifier: ^17.1.2
         version: 17.1.2

--- a/preload.js
+++ b/preload.js
@@ -1,10 +1,7 @@
-window.addEventListener('DOMContentLoaded', () => {
-    const replaceText = (selector, text) => {
-        const element = document.getElementById(selector);
-        if (element) element.innerText = text;
-    };
+const { contextBridge } = require('electron');
 
-    for (const type of ['chrome', 'node', 'electron']) {
-        replaceText(`${type}-version`, process.versions[type]);
-    }
+contextBridge.exposeInMainWorld('versions', {
+    node: process.versions.node,
+    chrome: process.versions.chrome,
+    electron: process.versions.electron,
 });

--- a/src/MusicPlayer.js
+++ b/src/MusicPlayer.js
@@ -22,6 +22,7 @@ export default class MusicPlayer {
         this.playerShow = false;
         this.player.style.display = 'none';
         this.trackList = [];
+        this.blobUrls = [];
         this.currentSong = 0;
         this.isPlaying = false;
         this.playlistEls = null;
@@ -52,6 +53,9 @@ export default class MusicPlayer {
         this._setPlayIcon(false);
         this.playList.innerHTML = '';
         this.currentSong = 0;
+
+        // Revoke any existing blob URLs before creating new ones
+        this._revokeBlobUrls();
         this.trackList = [];
 
         const files = this.input.files;
@@ -63,7 +67,9 @@ export default class MusicPlayer {
                 files[i].name.indexOf('.'),
             );
             this.playList.appendChild(listItem);
-            this.trackList.push(window.URL.createObjectURL(files[i]));
+            const blobUrl = window.URL.createObjectURL(files[i]);
+            this.trackList.push(blobUrl);
+            this.blobUrls.push(blobUrl);
         }
 
         this.audio.src = this.trackList[this.currentSong];
@@ -171,6 +177,14 @@ export default class MusicPlayer {
     _setPlayIcon(playing) {
         this.iconPlay.style.display = playing ? 'none' : 'inline';
         this.iconPause.style.display = playing ? 'inline' : 'none';
+    }
+
+    /** Revoke all stored blob URLs to free memory. */
+    _revokeBlobUrls() {
+        for (const url of this.blobUrls) {
+            window.URL.revokeObjectURL(url);
+        }
+        this.blobUrls = [];
     }
 
     /** Toggle player visibility with the P key. */


### PR DESCRIPTION
## Changes

- Add Content Security Policy meta tag to index.html (restricts to self, allows unsafe-inline styles and blob: for audio)
- Move electron from dependencies to devDependencies
- Rewrite preload.js to use contextBridge.exposeInMainWorld, remove dead DOM references
- Add blob URL revocation in MusicPlayer to prevent memory leaks

## Issue

Closes #52

## Testing

- [x] Tested with pnpm start
- [x] No console errors
- [x] App launches and runs normally

## Checklist

- [x] Code follows AGENTS.md conventions
- [x] CHANGELOG.md updated
- [x] TODO.md updated