### PR TITLE
fix: optimize clearScreen/fillScreen to clear exact canvas area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## 2026-02-15
 
+- fix: Optimize clearScreen/fillScreen to clear exact canvas area instead of 9x
 - feat: Implement devicePixelRatio scaling for sharp rendering on HiDPI displays
 - perf: Defer MusicPlayer and FrequencyAnalyser instantiation to init()
 - fix: Add Content Security Policy meta tag to index.html

--- a/TODO.md
+++ b/TODO.md
@@ -130,7 +130,7 @@
   `ctx.save() → ctx.resetTransform() → ctx.clearRect(0, 0, w, h) → ctx.restore()`
   for efficient clearing regardless of transform state.
 
-- [ ] Optimize `clearScreen`/`fillScreen` in `AlgorithmLoader.js`
+- [x] Optimize `clearScreen`/`fillScreen` in `AlgorithmLoader.js`
 
 ### 3.3 — Cursor hide spawns unbounded timeouts
 

--- a/src/AlgorithmLoader.js
+++ b/src/AlgorithmLoader.js
@@ -61,11 +61,17 @@ export default class AlgorithmLoader {
     }
 
     clearScreen() {
-        this.ctx.clearRect(-this.w, -this.h, 3 * this.w, 3 * this.h);
+        this.ctx.save();
+        this.ctx.resetTransform();
+        this.ctx.clearRect(0, 0, this.w, this.h);
+        this.ctx.restore();
     }
 
     fillScreen() {
-        this.ctx.fillRect(-this.w, -this.h, 3 * this.w, 3 * this.h);
+        this.ctx.save();
+        this.ctx.resetTransform();
+        this.ctx.fillRect(0, 0, this.w, this.h);
+        this.ctx.restore();
     }
 
     rotateCanvasRadians(angle) {


### PR DESCRIPTION
## Summary

Optimizes `AlgorithmLoader.clearScreen()` and `fillScreen()` to clear/fill the exact canvas area instead of 9x the area.

## Problem

Both methods used `clearRect(-w, -h, 3*w, 3*h)` / `fillRect(-w, -h, 3*w, 3*h)` to handle rotated canvases, but this cleared 9x the actual canvas area on every frame for all 142 algorithms.

## Solution

Use `ctx.save()` → `ctx.resetTransform()` → operate on `(0, 0, w, h)` → `ctx.restore()`. This correctly clears/fills the actual canvas buffer regardless of transform state at 1/9th the cost.

## Changes

- `src/AlgorithmLoader.js` — Updated `clearScreen()` and `fillScreen()` to use `resetTransform`
- `CHANGELOG.md` — Added entry
- `TODO.md` — Marked item 3.2 as complete

Closes #56