### PR TITLE
fix: debounce cursor hide timeout and hide cursor on app launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## 2026-02-15
 
+- fix: Debounce cursor hide timeout and hide cursor on app launch
 - fix: Optimize clearScreen/fillScreen to clear exact canvas area instead of 9x
 - feat: Implement devicePixelRatio scaling for sharp rendering on HiDPI displays
 - perf: Defer MusicPlayer and FrequencyAnalyser instantiation to init()

--- a/TODO.md
+++ b/TODO.md
@@ -139,7 +139,8 @@
   previous one, spawning many concurrent timers during mouse movement.
 - **Fix:** Store the timeout ID and `clearTimeout` before creating a new one.
 
-- [ ] Debounce cursor hide timeout in `Spiral.js`
+- [x] Debounce cursor hide timeout in `Spiral.js`
+- [x] Hide cursor by default on app launch (shows only on mouse movement)
 
 ### 3.4 — Resize handler triggers immediate algorithm restart
 

--- a/src/Spiral.js
+++ b/src/Spiral.js
@@ -50,6 +50,9 @@ export default class Spiral {
         // Silent mode toggle
         this.silent = false;
 
+        // Cursor hide timeout ID for debouncing
+        this.cursorHideTimeout = null;
+
         // Initialize the application
         this.init();
     }
@@ -57,6 +60,9 @@ export default class Spiral {
     init() {
         // display some user tips on screen
         this.canvas.focus();
+
+        // Hide cursor by default on launch
+        this.canvas.style.cursor = 'none';
         this.displayMessage('WELCOME');
         setTimeout(() => {
             this.displayMessage('PRESS H FOR HELP');
@@ -192,8 +198,16 @@ export default class Spiral {
 
         // on mousemove, show the cursor
         this.canvas.addEventListener('mousemove', () => {
+            // Show cursor
             this.canvas.style.cursor = 'pointer';
-            setTimeout(() => {
+
+            // Clear existing timeout to prevent unbounded setTimeout accumulation
+            if (this.cursorHideTimeout) {
+                clearTimeout(this.cursorHideTimeout);
+            }
+
+            // Set new timeout and store ID for debouncing
+            this.cursorHideTimeout = setTimeout(() => {
                 this.canvas.style.cursor = 'none';
             }, 4000);
         });


### PR DESCRIPTION
- Add cursorHideTimeout instance variable to track timeout ID
- Set initial cursor state to hidden in init() method
- Clear existing timeout before creating new one in mousemove handler
- Prevents unbounded setTimeout accumulation and memory leaks
- Cursor now hidden by default on launch, shows on mouse movement

Fixes #58