### PR TITLE
refactor: Replace canvas.click() with direct method calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 <!-- Format: ## YYYY-MM-DD followed by one-liner entries. -->
 
+## 2026-02-16
+
+- refactor: Replace canvas.click() with direct method calls — decouple algorithm
+  transition logic from DOM events by extracting changeAlgorithm() method
+
 ## 2026-02-15
 
 - fix: Debounce cursor hide timeout and hide cursor on app launch

--- a/src/Spiral.js
+++ b/src/Spiral.js
@@ -76,7 +76,7 @@ export default class Spiral {
         // make algorithms auto-change if not in manual mode
         if (!this.manual && !this.devMode) {
             this.regen = setInterval(() => {
-                this.canvas.click();
+                this.changeAlgorithm();
             }, this.autoChange * 1000);
         }
 
@@ -116,7 +116,7 @@ export default class Spiral {
                 clearTimeout(this.resizeTimeout);
             }
             this.resizeTimeout = setTimeout(() => {
-                this.canvas.click();
+                this.changeAlgorithm();
                 this.resizeTimeout = null;
             }, 250);
         });
@@ -126,7 +126,7 @@ export default class Spiral {
             switch (e.code) {
                 case 'Space':
                     if (!this.devMode) {
-                        this.canvas.click();
+                        this.changeAlgorithm();
                     }
                     break;
                 case 'KeyF':
@@ -172,41 +172,7 @@ export default class Spiral {
 
         // on canvas click, generate a new spiral
         this.canvas.addEventListener('click', () => {
-            if (this.devMode) return;
-            this.ctx.save();
-            // clear any timers
-            this.stopCurrentAlgorithm();
-
-            clearInterval(this.regen);
-            this.t = 0;
-            this.stagger = 0;
-
-            // setup new auto-change timer if not in manual mode
-            if (!this.manual) {
-                this.regen = setInterval(() => {
-                    this.canvas.click();
-                }, this.autoChange * 1000);
-            }
-
-            // new random speed
-            this.algorithmLoader.speed = random(2, 6);
-
-            // canvas resets
-            this.ctx.restore();
-
-            // picks a transition mode
-            this.canvas.style.background = 'transparent';
-            this.clearMethod();
-
-            // reset stroke and fill styles
-            this.ctx.strokeStyle = randomColor(5, 255, 0.8, 0.8);
-            this.ctx.fillStyle = randomColor(5, 255, 0.5, 0.5);
-
-            // begin new path
-            this.ctx.beginPath();
-
-            // selects next algorithm
-            this.chooseAlgos();
+            this.changeAlgorithm();
         });
 
         // on mousemove, show the cursor
@@ -257,6 +223,46 @@ export default class Spiral {
         this.currentAlgorithm = new AlgorithmClass(this.ctx, this.w, this.h);
         // display algorithm name
         this.displayAlgorithmName(this.currentAlgorithm.name);
+    }
+
+    // Triggers a new algorithm transition — called by auto-change timer,
+    // resize handler, keyboard shortcuts, and canvas click events
+    changeAlgorithm() {
+        if (this.devMode) return;
+        this.ctx.save();
+        // clear any timers
+        this.stopCurrentAlgorithm();
+
+        clearInterval(this.regen);
+        this.t = 0;
+        this.stagger = 0;
+
+        // setup new auto-change timer if not in manual mode
+        if (!this.manual) {
+            this.regen = setInterval(() => {
+                this.changeAlgorithm();
+            }, this.autoChange * 1000);
+        }
+
+        // new random speed
+        this.algorithmLoader.speed = random(2, 6);
+
+        // canvas resets
+        this.ctx.restore();
+
+        // picks a transition mode
+        this.canvas.style.background = 'transparent';
+        this.clearMethod();
+
+        // reset stroke and fill styles
+        this.ctx.strokeStyle = randomColor(5, 255, 0.8, 0.8);
+        this.ctx.fillStyle = randomColor(5, 255, 0.5, 0.5);
+
+        // begin new path
+        this.ctx.beginPath();
+
+        // selects next algorithm
+        this.chooseAlgos();
     }
 
     // chooses a transition method when spirals change
@@ -339,7 +345,7 @@ export default class Spiral {
                     clearTimeout(this.resizeTimeout);
                 }
                 this.resizeTimeout = setTimeout(() => {
-                    this.canvas.click();
+                    this.changeAlgorithm();
                     this.resizeTimeout = null;
                 }, 250);
 


### PR DESCRIPTION
## Changes

- Extract `changeAlgorithm()` method from canvas click listener
- Replace all `canvas.click()` calls with direct `changeAlgorithm()` calls:
  - Auto-change timer
  - Resize debounce handler  
  - Space key shortcut
  - DPR change handler
  - Canvas click listener (now 3-line wrapper)
- Decouples algorithm transition logic from DOM events

## Issue

Closes #61

## Testing

- [x] Tested in pnpm start
- [x] No console errors
- [x] All 5 transition triggers work correctly
- [x] Canvas click still functional

## Checklist

- [x] Code follows AGENTS.md conventions
- [x] CHANGELOG.md updated
- [x] Related files updated (if applicable)