### PR TITLE
refactor: Deduplicate stopCurrentAlgorithm() calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - refactor: Replace canvas.click() with direct method calls — decouple algorithm
   transition logic from DOM events by extracting changeAlgorithm() method
+- refactor: Deduplicate stopCurrentAlgorithm() calls — remove redundant calls from
+  clearMethod() and chooseAlgos(), keeping only the call in changeAlgorithm()
 
 ## 2026-02-15
 

--- a/TODO.md
+++ b/TODO.md
@@ -177,7 +177,7 @@
 - **Fix:** Remove redundant calls; keep only the first one in the transition
   flow.
 
-- [ ] Deduplicate `stopCurrentAlgorithm()` calls
+- [x] Deduplicate `stopCurrentAlgorithm()` calls
 
 ### 4.3 — Consolidate duplicate `random`/`randomColor`
 

--- a/src/Spiral.js
+++ b/src/Spiral.js
@@ -206,8 +206,6 @@ export default class Spiral {
         this.ctx.shadowBlur = 0;
         this.ctx.setLineDash([]);
         this.ctx.save();
-        // clear any timers
-        this.stopCurrentAlgorithm();
         let AlgorithmClass = this.algorithmChooser.getRandomAlgorithm();
         if (this.devMode) {
             if (
@@ -267,9 +265,6 @@ export default class Spiral {
 
     // chooses a transition method when spirals change
     clearMethod() {
-        // clear the running algorithm
-        this.stopCurrentAlgorithm();
-
         const clearMethodPick = Math.random();
         // clears to black a portion of the screen based on the canvas size and its rotation at the moment
         if (clearMethodPick < 0.25) {


### PR DESCRIPTION
## Changes

- Remove redundant `stopCurrentAlgorithm()` call from `clearMethod()`
- Remove redundant `stopCurrentAlgorithm()` call and comment from `chooseAlgos()`
- Keep single call in `changeAlgorithm()` as the entry point
- Simplifies algorithm transition flow (3 calls → 1 call per transition)

## Issue

Closes #63

## Testing

- [x] Tested in pnpm start
- [x] No console errors
- [x] Algorithm transitions work correctly
- [x] Only one stopCurrentAlgorithm() call per transition

## Checklist

- [x] Code follows AGENTS.md conventions
- [x] CHANGELOG.md updated
- [x] TODO.md updated (task 4.2 marked complete)