### PR TITLE
refactor: Consolidate duplicate random and randomColor implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   transition logic from DOM events by extracting changeAlgorithm() method
 - refactor: Deduplicate stopCurrentAlgorithm() calls — remove redundant calls from
   clearMethod() and chooseAlgos(), keeping only the call in changeAlgorithm()
+- refactor: Consolidate duplicate random/randomColor implementations — make
+  AlgorithmLoader delegate to randomUtils.js for single source of truth
 
 ## 2026-02-15
 

--- a/TODO.md
+++ b/TODO.md
@@ -188,7 +188,7 @@
 - **Fix:** Make `AlgorithmLoader` static methods delegate to `randomUtils.js`
   (single source of truth).
 
-- [ ] Consolidate `random`/`randomColor` into one implementation
+- [x] Consolidate `random`/`randomColor` into one implementation
 
 ### 4.4 — Fix `Vector` naming inconsistency
 

--- a/src/AlgorithmLoader.js
+++ b/src/AlgorithmLoader.js
@@ -1,19 +1,15 @@
 import Particle from './utils/Particle.js';
 import Vector from './utils/Vector.js';
 import mathUtils from './utils/math.js';
+import { random, randomColor } from './utils/randomUtils.js';
 
 export default class AlgorithmLoader {
     static random(min, max) {
-        const num = Math.floor(Math.random() * (max - min)) + min;
-        return num;
+        return random(min, max);
     }
 
     static randomColor(minC = 0, maxC = 255, minA = 0.1, maxA = 1) {
-        const r = this.random(minC, maxC);
-        const g = this.random(minC, maxC);
-        const b = this.random(minC, maxC);
-        const a = +(Math.random() * (maxA - minA) + minA).toFixed(3);
-        return `rgba(${r}, ${g}, ${b}, ${a})`;
+        return randomColor(minC, maxC, minA, maxA);
     }
 
     static mathUtils = mathUtils;


### PR DESCRIPTION
## Changes

- Import `random` and `randomColor` from `randomUtils.js` in `AlgorithmLoader.js`
- Make `AlgorithmLoader.random()` delegate to `randomUtils.random()`
- Make `AlgorithmLoader.randomColor()` delegate to `randomUtils.randomColor()`
- Establish `randomUtils.js` as single source of truth
- Update TODO.md to mark task 4.3 as complete
- Update CHANGELOG.md

## Issue

Closes #65

## Testing

- [x] Tested in pnpm start
- [x] No console errors
- [x] Feature/fix works as expected

## Checklist

- [x] Code follows [AGENTS.md](AGENTS.md) conventions
- [x] CHANGELOG.md updated
- [x] Related files updated (if applicable)