### PR TITLE
feat: Add accessibility labels to UI controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## 2026-02-16
 
+- feat: Add accessibility labels to player controls, progress bar, and canvas —
+  add aria-label and title attributes for screen reader support
 - refactor: Replace canvas.click() with direct method calls — decouple algorithm
   transition logic from DOM events by extracting changeAlgorithm() method
 - refactor: Deduplicate stopCurrentAlgorithm() calls — remove redundant calls from

--- a/TODO.md
+++ b/TODO.md
@@ -231,8 +231,8 @@
   `aria-label`, no `title` attributes. Invisible to screen readers.
 - **Fix:** Add `aria-label` and `title` attributes to all player buttons.
 
-- [ ] Add `aria-label` to all player control buttons
-- [ ] Add `title` tooltips to player control buttons
+- [x] Add `aria-label` to all player control buttons
+- [x] Add `title` tooltips to player control buttons
 
 ### 5.2 — `<progress>` element has no accessible label
 
@@ -240,7 +240,7 @@
 - **Issue:** The progress bar has no label for assistive technology.
 - **Fix:** Add `aria-label="Playback progress"` or a visually hidden `<label>`.
 
-- [ ] Add accessible label to `<progress>` element
+- [x] Add accessible label to `<progress>` element
 
 ### 5.3 — Canvas has no text alternative
 
@@ -248,7 +248,7 @@
 - **Issue:** The `<canvas>` element has no `role` or `aria-label`.
 - **Fix:** Add `role="img"` and `aria-label="Music visualizer"`.
 
-- [ ] Add `role` and `aria-label` to canvas
+- [x] Add `role` and `aria-label` to canvas
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
         <title>The Spiral</title>
     </head>
     <body>
-        <canvas id="canvas"></canvas>
+        <canvas id="canvas" role="img" aria-label="Music visualizer"></canvas>
         <div id="hud">
             <div id="msg"></div>
             <div id="algos"></div>
@@ -81,7 +81,7 @@
                 <input type="file" id="input" accept="audio/*" multiple />
                 <ol id="playlist"></ol>
                 <div id="controls">
-                    <button id="prev">
+                    <button id="prev" aria-label="Previous track" title="Previous track">
                         <svg
                             class="icon"
                             xmlns="http://www.w3.org/2000/svg"
@@ -104,7 +104,7 @@
                             />
                         </svg>
                     </button>
-                    <button id="play">
+                    <button id="play" aria-label="Play" title="Play">
                         <svg
                             id="icon-play"
                             class="icon"
@@ -136,7 +136,7 @@
                             />
                         </svg>
                     </button>
-                    <button id="stop">
+                    <button id="stop" aria-label="Stop" title="Stop">
                         <svg
                             class="icon"
                             xmlns="http://www.w3.org/2000/svg"
@@ -156,7 +156,7 @@
                             />
                         </svg>
                     </button>
-                    <button id="next">
+                    <button id="next" aria-label="Next track" title="Next track">
                         <svg
                             class="icon"
                             xmlns="http://www.w3.org/2000/svg"
@@ -182,7 +182,7 @@
                 </div>
             </div>
             <div id="progress">
-                <progress id="progress-percent" max="100" value="0"></progress>
+                <progress id="progress-percent" max="100" value="0" aria-label="Playback progress"></progress>
             </div>
         </div>
 


### PR DESCRIPTION
## Changes

- Add `role="img"` and `aria-label="Music visualizer"` to canvas element
- Add `aria-label` and `title` attributes to all player control buttons:
  - Previous track button: "Previous track"
  - Play button: "Play"
  - Stop button: "Stop"
  - Next track button: "Next track"
- Add `aria-label="Playback progress"` to progress element
- Update TODO.md to mark Phase 5 tasks as complete
- Update CHANGELOG.md

## Issue

Closes #70

## Testing

- [x] Tested in pnpm start
- [x] No console errors
- [x] Feature works as expected
- [x] No visual changes to UI

## Checklist

- [x] Code follows [AGENTS.md](AGENTS.md) conventions
- [x] CHANGELOG.md updated
- [x] Related files updated (TODO.md)