### PR TITLE
Refactor: simplify canvas clearing to single black fill

### DIFF
--- a/src/Spiral.js
+++ b/src/Spiral.js
@@ -250,7 +250,13 @@ export default class Spiral {
 
         // picks a transition mode
         this.canvas.style.background = 'transparent';
-        this.clearMethod();
+
+        // fill entire canvas with black, ignoring any accumulated rotation
+        this.ctx.save();
+        this.ctx.resetTransform();
+        this.ctx.fillStyle = 'black';
+        this.ctx.fillRect(0, 0, this.canvas.width, this.canvas.height);
+        this.ctx.restore();
 
         // reset stroke and fill styles
         this.ctx.strokeStyle = randomColor(5, 255, 0.8, 0.8);
@@ -261,29 +267,6 @@ export default class Spiral {
 
         // selects next algorithm
         this.chooseAlgos();
-    }
-
-    // chooses a transition method when spirals change
-    clearMethod() {
-        const clearMethodPick = Math.random();
-        // clears to black a portion of the screen based on the canvas size and its rotation at the moment
-        if (clearMethodPick < 0.25) {
-            this.ctx.clearRect(0, 0, this.w, this.h);
-        } else if (clearMethodPick < 0.5) {
-            // makes semi-transparent a portion of the screen based on the canvas size and its rotation at the moment
-            this.ctx.fillStyle = 'rgba(0, 0, 0, 0.75)';
-            this.ctx.fillRect(0, 0, this.w, this.h);
-        } else if (clearMethodPick < 0.75) {
-            // colors a portion of the screen based on the canvas size and its rotation at the moment, with random transparency
-            this.ctx.fillStyle = randomColor(5, 255, 0.15, 0.9);
-            this.ctx.fillRect(0, 0, this.w, this.h);
-        } else {
-            // completely fills the screen with black
-            this.canvas.width = this.canvas.height = 0;
-            this._applyDpr();
-        }
-
-        this.ctx.strokeStyle = randomColor(5, 255, 0.8, 0.8);
     }
 
     displayAlgorithmName(name) {


### PR DESCRIPTION
Replace the `clearMethod()` function with a straightforward full-canvas black fill operation.

**Changes:**
- Remove `clearMethod()` which randomly selected between 4 different clearing strategies
- Implement direct black fill using `fillRect()` with `resetTransform()` to ignore canvas rotation
- Reduce code complexity by ~24 lines while maintaining core functionality

**Benefits:**
- Simpler, more predictable clearing behavior
- Removes unnecessary randomization logic
- Easier to understand and maintain