### PR TITLE
fix: consistent 5s algorithm name display duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 <!-- Format: ## YYYY-MM-DD followed by one-liner entries. -->
 
+## 2026-02-19
+
+- fix: Algorithm name display now consistently shows for 5 seconds — clear stale
+  timeout on each algorithm change to prevent premature hiding
+
 ## 2026-02-16
 
 - feat: Add accessibility labels to player controls, progress bar, and canvas —

--- a/src/Spiral.js
+++ b/src/Spiral.js
@@ -34,6 +34,7 @@ export default class Spiral {
         this.messageElement = document.querySelector('#msg');
 
         // Setup algorithm display
+        this.algorithmNameTimer = null;
         this.algosDisplayElement = document.querySelector('#algos');
 
         // Setup help display
@@ -276,10 +277,11 @@ export default class Spiral {
 
     displayAlgorithmName(name) {
         if (this.silent) return;
+        clearTimeout(this.algorithmNameTimer);
         this.algosDisplayElement.textContent = `${name.toUpperCase()}`;
         this.algosDisplayElement.style.display = 'block';
 
-        setTimeout(() => {
+        this.algorithmNameTimer = setTimeout(() => {
             this.algosDisplayElement.style.display = 'none';
             this.algosDisplayElement.textContent = '';
         }, 5000);


### PR DESCRIPTION
## Summary
- Clear stale `setTimeout` in `displayAlgorithmName()` before creating a new one, preventing previous callbacks from hiding the name prematurely
- Initialize `this.algorithmNameTimer` in the constructor for consistency with other timer properties
- Mirrors the existing pattern in `displayMessage()` which already handles this correctly

Closes #76

## Test plan
- [x] `pnpm start` — launch the app
- [x] Rapidly press Space / arrow keys to change algorithms
- [x] Confirm the name consistently stays visible for 5 seconds after the last change
- [x] Let auto-change trigger and verify same consistent behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)