### PR TITLE
feat: Add elapsed/remaining and total time display to music player progress bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## 2026-02-22
 
+- feat: Add elapsed/remaining and total time display to music player progress bar
 - refactor: Extract HUDController, KeyboardController, and TransitionManager
   from Spiral.js — reduce god object from ~375 to ~200 lines by splitting HUD
   overlay, keyboard shortcuts, and algorithm lifecycle into focused modules

--- a/index.html
+++ b/index.html
@@ -190,12 +190,14 @@
                 </div>
             </div>
             <div id="progress">
+                <span id="time-elapsed" title="Click to toggle remaining time"></span>
                 <progress
                     id="progress-percent"
                     max="100"
                     value="0"
                     aria-label="Playback progress"
                 ></progress>
+                <span id="time-total"></span>
             </div>
         </div>
 

--- a/src/MusicPlayer.js
+++ b/src/MusicPlayer.js
@@ -19,9 +19,12 @@ export default class MusicPlayer {
         this.nextBtn = document.getElementById('next');
         this.audio = document.getElementById('audio');
         this.progress = document.getElementById('progress-percent');
+        this.elapsedEl = document.getElementById('time-elapsed');
+        this.totalEl = document.getElementById('time-total');
 
         // State
         this.playerShow = false;
+        this.showRemaining = false;
         this.player.style.display = 'none';
         this.trackList = [];
         this.blobUrls = [];
@@ -39,12 +42,20 @@ export default class MusicPlayer {
         this.stopBtn.addEventListener('click', () => this.stopPlayback());
         this.nextBtn.addEventListener('click', () => this.playNext());
         this.prevBtn.addEventListener('click', () => this.playPrev());
+        this.audio.addEventListener('loadedmetadata', () => {
+            this.totalEl.textContent = this._formatTime(this.audio.duration);
+            this.elapsedEl.textContent = '0:00';
+        });
         this.audio.addEventListener('timeupdate', () =>
             this._displayProgress(),
         );
         this.audio.addEventListener('ended', () => this.playNext());
         this.progress.addEventListener('mousedown', () => this.audio.pause());
         this.progress.addEventListener('mouseup', (e) => this._scrub(e));
+        this.elapsedEl.addEventListener('click', () => {
+            this.showRemaining = !this.showRemaining;
+            this._displayProgress();
+        });
     }
 
     /** Process file input and build the playlist. */
@@ -58,6 +69,9 @@ export default class MusicPlayer {
         // Revoke any existing blob URLs before creating new ones
         this._revokeBlobUrls();
         this.trackList = [];
+
+        this.elapsedEl.textContent = '';
+        this.totalEl.textContent = '';
 
         const files = this.input.files;
         if (!files?.length) return;
@@ -123,6 +137,8 @@ export default class MusicPlayer {
         this.audio.pause();
         this.audio.currentTime = 0;
         this.progress.value = 0;
+        this.elapsedEl.textContent = '0:00';
+        this.totalEl.textContent = '0:00';
         this.currentSong--;
         if (this.currentSong < 0) this.currentSong = this.trackList.length - 1;
         this._updatePlaylistStyle();
@@ -141,6 +157,8 @@ export default class MusicPlayer {
         this.audio.pause();
         this.audio.currentTime = 0;
         this.progress.value = 0;
+        this.elapsedEl.textContent = '0:00';
+        this.totalEl.textContent = '0:00';
         this.currentSong++;
         if (this.currentSong > this.trackList.length - 1) this.currentSong = 0;
         this._updatePlaylistStyle();
@@ -153,17 +171,33 @@ export default class MusicPlayer {
         }
     }
 
-    /** Update the progress bar based on current playback position. */
+    /** Update the progress bar and time displays based on current playback position. */
     _displayProgress() {
         if (this.audio.duration === 0) {
             this.progress.value = 0;
             return;
         }
         const currentTime = this.audio.currentTime;
-        const progressPercent = (currentTime / this.audio.duration) * 100;
+        const duration = this.audio.duration;
+        const progressPercent = (currentTime / duration) * 100;
         this.progress.value = Number.isFinite(progressPercent)
             ? progressPercent.toFixed(2)
             : '0';
+
+        if (this.showRemaining) {
+            this.elapsedEl.textContent = '-' + this._formatTime(duration - currentTime);
+        } else {
+            this.elapsedEl.textContent = this._formatTime(currentTime);
+        }
+        this.totalEl.textContent = this._formatTime(duration);
+    }
+
+    /** Format seconds into M:SS string. */
+    _formatTime(seconds) {
+        if (!Number.isFinite(seconds) || seconds < 0) return '0:00';
+        const m = Math.floor(seconds / 60);
+        const s = Math.floor(seconds % 60);
+        return `${m}:${s.toString().padStart(2, '0')}`;
     }
 
     /** Scrub to clicked position on the progress bar. */

--- a/style.css
+++ b/style.css
@@ -195,12 +195,50 @@ input[type='file'] {
     color: whitesmoke;
 }
 
+#progress {
+    display: flex;
+    align-items: center;
+    gap: 0.5em;
+    margin-top: 0.5em;
+    padding: 0 2.5em 0.5em;
+}
+
 progress {
-    margin: 0 auto;
-    width: 80%;
+    flex: 1;
     cursor: pointer;
-    display: block;
-    padding-bottom: 0.5em;
+    margin: 0 0.3em;
+    height: 6px;
+    -webkit-appearance: none;
+    appearance: none;
+    border-radius: 3px;
+}
+
+progress::-webkit-progress-bar {
+    background-color: #999;
+    border-radius: 3px;
+}
+
+progress::-webkit-progress-value {
+    background-color: orange;
+    border-radius: 3px;
+}
+
+#time-elapsed {
+    color: orange;
+    font-size: 0.72em;
+    cursor: pointer;
+    white-space: nowrap;
+    min-width: 2.8em;
+    text-align: right;
+    letter-spacing: 0.04em;
+}
+
+#time-total {
+    color: #999;
+    font-size: 0.72em;
+    white-space: nowrap;
+    min-width: 2.8em;
+    letter-spacing: 0.04em;
 }
 
 @media (max-width: 545px) {


### PR DESCRIPTION
## Changes

- Add `#time-elapsed` span to the left of the progress bar showing current playback position in `M:SS` format
- Add `#time-total` span to the right showing track duration, populated immediately on file load via `loadedmetadata`
- Clicking elapsed toggles between elapsed and remaining time (remaining prefixed with `-`)
- Both spans are empty before any files are loaded and reset on track change (next/prev)
- Progress bar restyled: slim height (5px), fully rounded ends, grey unfilled track, orange fill, centered with side padding

## Issue

Closes #84

## Testing

- [x] Tested in pnpm start
- [x] No console errors
- [x] Elapsed time counts up live during playback
- [x] Total duration shows immediately on file load
- [x] Clicking elapsed toggles to remaining and back
- [x] Track changes reset both displays
- [x] Empty on app start / before files loaded

## Checklist

- [x] Code follows [AGENTS.md](AGENTS.md) conventions
- [x] CHANGELOG.md updated
- [x] Related files updated (index.html, style.css, src/MusicPlayer.js)