### PR TITLE
feat: Add playlist accordion with track-jump to music player

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## 2026-02-22
 
+- feat: Add playlist accordion with track-jump to music player — current track name and chevron toggle displayed in player bar; clicking chevron opens/closes animated accordion showing full playlist; clicking a track jumps to it with a 200ms delay (debounced)
 - feat: Add elapsed/remaining and total time display to music player progress bar
 - refactor: Extract HUDController, KeyboardController, and TransitionManager
   from Spiral.js — reduce god object from ~375 to ~200 lines by splitting HUD

--- a/index.html
+++ b/index.html
@@ -79,7 +79,29 @@
             <div id="picker">
                 <label id="click-label" for="input">Add Track(s)</label>
                 <input type="file" id="input" accept="audio/*" multiple />
-                <ol id="playlist"></ol>
+                <div id="now-playing">
+                    <span id="track-name"></span>
+                    <button
+                        id="playlist-toggle"
+                        aria-label="Toggle playlist"
+                        title="Toggle playlist"
+                    >
+                        <svg
+                            class="icon"
+                            xmlns="http://www.w3.org/2000/svg"
+                            viewBox="0 0 512 512"
+                        >
+                            <path
+                                fill="none"
+                                stroke="currentColor"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="48"
+                                d="M112 184l144 144 144-144"
+                            />
+                        </svg>
+                    </button>
+                </div>
                 <div id="controls">
                     <button
                         id="prev"
@@ -189,7 +211,10 @@
                     </button>
                 </div>
             </div>
-            <div id="progress">
+            <div id="playlist-accordion">
+            <ol id="playlist"></ol>
+        </div>
+        <div id="progress">
                 <span id="time-elapsed" title="Click to toggle remaining time"></span>
                 <progress
                     id="progress-percent"

--- a/src/MusicPlayer.js
+++ b/src/MusicPlayer.js
@@ -21,10 +21,15 @@ export default class MusicPlayer {
         this.progress = document.getElementById('progress-percent');
         this.elapsedEl = document.getElementById('time-elapsed');
         this.totalEl = document.getElementById('time-total');
+        this.trackNameEl = document.getElementById('track-name');
+        this.playlistToggle = document.getElementById('playlist-toggle');
+        this.accordionEl = document.getElementById('playlist-accordion');
 
         // State
         this.playerShow = false;
         this.showRemaining = false;
+        this.playlistOpen = false;
+        this._jumpTimeout = null;
         this.player.style.display = 'none';
         this.trackList = [];
         this.blobUrls = [];
@@ -56,6 +61,9 @@ export default class MusicPlayer {
             this.showRemaining = !this.showRemaining;
             this._displayProgress();
         });
+        this.playlistToggle.addEventListener('click', () =>
+            this._togglePlaylist(),
+        );
     }
 
     /** Process file input and build the playlist. */
@@ -87,6 +95,7 @@ export default class MusicPlayer {
             // Optionally, if you ever use innerHTML or attributes, escape:
             // listItem.innerHTML = htmlEscape(baseName);
             // listItem.setAttribute('data-filename', htmlEscape(files[i].name));
+            listItem.addEventListener('click', () => this.jumpToTrack(i));
             this.playList.appendChild(listItem);
             const blobUrl = window.URL.createObjectURL(files[i]);
             this.trackList.push(blobUrl);
@@ -95,9 +104,11 @@ export default class MusicPlayer {
 
         this.audio.src = this.trackList[this.currentSong];
         this.playlistEls = document.getElementsByClassName('list-item');
-        this.playlistEls[this.currentSong].scrollIntoView();
+        this.playlistEls[this.currentSong].scrollIntoView({ block: 'nearest' });
         this.playlistEls[this.currentSong].style.color =
             'rgba(255, 165, 0, 0.5)';
+        this.playlistToggle.classList.add('visible');
+        this._updateTrackName();
     }
 
     /** Play or pause the current track. */
@@ -215,13 +226,45 @@ export default class MusicPlayer {
     _updatePlaylistStyle() {
         [...this.playlistEls].forEach((el) => (el.style.color = '#555'));
         this.playlistEls[this.currentSong].style.color = 'orange';
-        this.playlistEls[this.currentSong].scrollIntoView();
+        this.playlistEls[this.currentSong].scrollIntoView({ block: 'nearest' });
+        this._updateTrackName();
     }
 
     /** Toggle the play/pause icon SVGs. */
     _setPlayIcon(playing) {
         this.iconPlay.style.display = playing ? 'none' : 'inline';
         this.iconPause.style.display = playing ? 'inline' : 'none';
+    }
+
+    /** Toggle the playlist accordion open/closed. */
+    _togglePlaylist() {
+        this.playlistOpen = !this.playlistOpen;
+        this.accordionEl.classList.toggle('open', this.playlistOpen);
+        this.playlistToggle.classList.toggle('open', this.playlistOpen);
+    }
+
+    /** Update the now-playing track name display. */
+    _updateTrackName() {
+        if (!this.playlistEls) return;
+        this.trackNameEl.textContent =
+            this.playlistEls[this.currentSong]?.textContent ?? '';
+    }
+
+    /** Jump directly to a track and start playback. */
+    jumpToTrack(index) {
+        if (!this.playlistEls || index === this.currentSong) return;
+        this.audio.pause();
+        this.audio.currentTime = 0;
+        this.progress.value = 0;
+        this.elapsedEl.textContent = '0:00';
+        this.totalEl.textContent = '0:00';
+        this.currentSong = index;
+        this._updatePlaylistStyle();
+        this.audio.src = this.trackList[this.currentSong];
+        this.isPlaying = true;
+        this._setPlayIcon(true);
+        clearTimeout(this._jumpTimeout);
+        this._jumpTimeout = setTimeout(() => this.audio.play(), 200);
     }
 
     /** Revoke all stored blob URLs to free memory. */

--- a/style.css
+++ b/style.css
@@ -144,15 +144,78 @@ input[type='file'] {
     background: rgba(255, 69, 0, 0.6);
 }
 
+#now-playing {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5em;
+    flex: 1;
+    min-width: 0;
+}
+
+#track-name {
+    color: orange;
+    font-size: 0.85em;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    flex: 0 1 auto;
+    min-width: 0;
+}
+
+#playlist-toggle {
+    background: transparent;
+    border: none;
+    color: #999;
+    cursor: pointer;
+    padding: 0 0.1em;
+    line-height: 0;
+    flex-shrink: 0;
+    transition: color 0.2s, transform 0.35s ease;
+    outline: none;
+    display: none;
+}
+
+#playlist-toggle.visible {
+    display: inline-flex;
+}
+
+#playlist-toggle .icon {
+    width: 1.15em;
+    height: 1.15em;
+    vertical-align: middle;
+}
+
+#playlist-toggle:hover {
+    color: orange;
+}
+
+#playlist-toggle.open {
+    color: orange;
+    transform: rotate(180deg);
+}
+
+#playlist-accordion {
+    overflow: hidden;
+    max-height: 0;
+    opacity: 0;
+    transition: max-height 0.35s ease, opacity 0.3s ease;
+}
+
+#playlist-accordion.open {
+    max-height: 175px;
+    opacity: 1;
+}
+
 #playlist {
     color: #999;
     font-size: 0.9em;
     padding: 0.25em 1em;
-    max-height: 22px;
-    overflow-y: scroll;
-    margin-bottom: 0.1em;
-    margin-left: 0.2em;
+    max-height: 155px;
+    overflow-y: auto;
+    margin: 0;
     user-select: none;
+    list-style: none;
 }
 
 #playlist li {
@@ -162,6 +225,8 @@ input[type='file'] {
 
 .list-item {
     margin-left: 4px;
+    cursor: pointer;
+    transition: color 0.15s;
 }
 
 #controls {
@@ -250,12 +315,8 @@ progress::-webkit-progress-value {
         position: absolute;
         right: 1em;
     }
-    #playlist {
-        display: inline;
-        text-align: center;
-        margin-bottom: 0;
-        font-size: 0.85em;
-        max-height: 17px;
+    #now-playing {
+        margin: 0.2em 0;
     }
     #controls {
         margin-top: 0;


### PR DESCRIPTION
## Changes

- Add `#now-playing` row inside the picker bar: shows current track name (orange, truncated with ellipsis) and a chevron toggle button
- Chevron is hidden until files are loaded; rotates 180° when the accordion is open
- Add `#playlist-accordion` collapsible panel between the picker row and the progress bar — opens/closes with smooth CSS transitions (max-height + opacity)
- Playlist shows max ~5–6 tracks at once and is scrollable for larger playlists
- Clicking any track in the accordion jumps to it and starts playback after a 200ms debounced delay (rapid clicks cancel previous pending plays)
- Track name in the picker row updates whenever the current track changes (prev/next/auto-advance/jump)

## Issue

Closes #86

## Testing

- [x] Tested in pnpm start
- [x] No console errors
- [x] Track name and chevron appear after loading files
- [x] Accordion opens/closes with animation, pushing progress bar down
- [x] Clicking a track starts playback with brief delay; rapid clicks debounced correctly
- [x] Prev/next/auto-advance update the track name display
- [x] Scrollable with 7+ tracks loaded

## Checklist

- [x] Code follows [AGENTS.md](AGENTS.md) conventions
- [x] CHANGELOG.md updated
- [x] Related files updated (index.html, style.css, src/MusicPlayer.js)

🤖 Generated with [Claude Code](https://claude.com/claude-code)