### PR TITLE
feat: Add runtime dev mode for algorithm testing and transition debugging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,10 +50,11 @@ src/
   KeyboardController.js  Centralized keyboard shortcuts (all keys in one handler)
   TransitionManager.js   Algorithm lifecycle, canvas context reset, auto-change timer,
                            one-algorithm-at-a-time guarantee
+  DevModeController.js   Dev mode modal — algorithm pair selection for testing transitions
   MusicPlayer.js       Audio playback, playlist management, progress bar
-  AlgorithmChooser.js  Static imports of all 142 algos, random selection (avoids last 50)
+  AlgorithmChooser.js  Static imports of all 141 algos, random selection (avoids last 50)
   AlgorithmLoader.js   Base class for all algorithms (draw loop, helpers, stop/start)
-  algos/               142 self-contained algorithm classes (one per file)
+  algos/               141 self-contained algorithm classes (one per file)
   utils/
     Vector.js          2D vector (add, subtract, multiply, divide, angle, length)
     Particle.js        Physics particle (position, velocity, gravity, springs, friction, bounce)
@@ -84,17 +85,19 @@ assets/
 | `main.js`                 | Electron main process entry                                                              |
 | `preload.js`              | Context bridge, version injection                                                        |
 | `renderer.js`             | Renderer entry: imports polyfills, instantiates Spiral                                   |
-| `index.html`              | DOM structure: canvas, HUD, player controls                                              |
+| `index.html`              | DOM structure: canvas, HUD, player controls, dev mode modal                              |
 | `style.css`               | All styles                                                                               |
 | `src/Spiral.js`              | Orchestrator — canvas, DPR, resize, cursor; wires all modules                         |
 | `src/HUDController.js`      | HUD overlay — messages, algorithm name, silent mode, help toggle                      |
-| `src/KeyboardController.js` | Centralized keyboard shortcuts (Space, F, I, D, M, S, H, P)                          |
-| `src/TransitionManager.js`  | Algorithm lifecycle, canvas context reset, auto-change timer                          |
+| `src/KeyboardController.js` | Centralized keyboard shortcuts (Space, F, I, D, M, S, H, P, E)                        |
+| `src/TransitionManager.js`  | Algorithm lifecycle, canvas context reset, auto-change timer, dev mode cycling        |
+| `src/DevModeController.js`  | Dev mode modal — algorithm pair selection for testing transitions                      |
 | `src/MusicPlayer.js`        | Audio playback, playlist, progress bar                                                |
 | `src/AlgorithmChooser.js`   | Algorithm registry and random picker                                                  |
 | `src/AlgorithmLoader.js`    | Base class for algorithms                                                             |
-| `src/algos/*.js`          | Individual algorithm classes (142 files)                                                 |
+| `src/algos/*.js`          | Individual algorithm classes (141 files)                                                 |
 | `src/utils/*.js`          | Shared utilities (Vector, Particle, math, random, roundRect polyfill, FrequencyAnalyser) |
+| `src/generated/`          | Auto-generated algorithm registry (algorithmRegistry.js)                                 |
 | `assets/js/`              | GSAP (loaded globally, not via npm)                                                      |
 | `assets/fonts/`           | Custom font files                                                                        |
 
@@ -164,7 +167,9 @@ assets/
 - `this.draw` in algorithms is **wrapped by `AlgorithmLoader`** to check
   `isRunning` — do not bypass this mechanism
 - All keyboard shortcuts are centralized in `KeyboardController.js` — modify
-  shortcuts there (Space, F, I, D, M, S, H, P)
+  shortcuts there (Space, F, I, D, M, S, H, P, E)
+- Dev mode (press E) allows testing algorithm transitions — it cycles between
+  two selectable algorithms (or random) and reuses the same interval/manual controls
 - GSAP is **global** (`window.gsap`) from the vendored file — `AlgorithmLoader`
   exposes it as a static ref
 - `FrequencyAnalyser` is instantiated once in `Spiral.js` init —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## 2026-02-22
 
+- feat: Add runtime dev mode for algorithm testing — modal with algorithm pair
+  selectors (press E), visual DEV badge, reuses existing interval/manual controls;
+  replaces hardcoded dev mode in renderer.js
 - feat: Add playlist accordion with track-jump to music player — current track name and chevron toggle displayed in player bar; clicking chevron opens/closes animated accordion showing full playlist; clicking a track jumps to it with a 200ms delay (debounced)
 - feat: Add elapsed/remaining and total time display to music player progress bar
 - refactor: Extract HUDController, KeyboardController, and TransitionManager

--- a/index.html
+++ b/index.html
@@ -16,6 +16,25 @@
             <div id="msg"></div>
             <div id="algos"></div>
         </div>
+        <div id="dev-mode">
+            <h3>DEV MODE</h3>
+            <label class="dev-row">
+                <input type="checkbox" id="dev-enable" />
+                <span>Enable Dev Mode</span>
+            </label>
+            <div class="dev-selects">
+                <label>
+                    <span>Algorithm A:</span>
+                    <select id="dev-algo-a"><option value="">Random</option></select>
+                </label>
+                <label>
+                    <span>Algorithm B:</span>
+                    <select id="dev-algo-b"><option value="">Random</option></select>
+                </label>
+            </div>
+            <p class="dev-hint">I/D = interval, M = manual mode, Space = trigger</p>
+        </div>
+        <div id="dev-badge">DEV</div>
         <div id="help">
             <div>
                 <h1>THE SPIRAL</h1>
@@ -68,6 +87,10 @@
                     <span class="keys"
                         >Press S for silence mode to toggle it on/off.
                     </span>
+                </p>
+                <p>
+                    <span class="keys">Press E for dev mode</span> to test
+                    specific algorithms and transitions.
                 </p>
                 <p>
                     <span class="help">H to open / close the help screen.</span>

--- a/renderer.js
+++ b/renderer.js
@@ -1,12 +1,7 @@
-// side effect import to patch the CanvasRenderingContext2D prototype with roundRect
 import './src/utils/roundRectExtra.js';
 
 import Spiral from './src/Spiral.js';
-import SoapyBubbles from './src/algos/SoapyBubbles.js';
 
-const devMode = false;
-const devAlgorithmClass = SoapyBubbles;
-
-const spiral = new Spiral({ devMode, devAlgorithmClass });
+const spiral = new Spiral();
 
 window.addEventListener('beforeunload', () => spiral.destroy());

--- a/src/DevModeController.js
+++ b/src/DevModeController.js
@@ -1,0 +1,97 @@
+import { algorithms } from './generated/algorithmRegistry.js';
+
+export default class DevModeController {
+    constructor({ transitionManager, hud }) {
+        this._transitionManager = transitionManager;
+        this._hud = hud;
+
+        this._modal = document.querySelector('#dev-mode');
+        this._enableCheckbox = document.querySelector('#dev-enable');
+        this._algoASelect = document.querySelector('#dev-algo-a');
+        this._algoBSelect = document.querySelector('#dev-algo-b');
+        this._badge = document.querySelector('#dev-badge');
+
+        this._active = false;
+        this._algoA = null;
+        this._algoB = null;
+
+        this._onEnableChangeHandler = (e) => this._onEnableChange(e.target.checked);
+        this._onAlgoAChangeHandler = (e) => this._onAlgoChange('A', e.target.value);
+        this._onAlgoBChangeHandler = (e) => this._onAlgoChange('B', e.target.value);
+
+        this._populateSelects();
+        this._bindEvents();
+    }
+
+    _populateSelects() {
+        const fragment = document.createDocumentFragment();
+        
+        algorithms.forEach((AlgoClass, index) => {
+            const option = document.createElement('option');
+            option.value = index;
+            option.textContent = AlgoClass.name;
+            fragment.appendChild(option);
+        });
+
+        this._algoASelect.appendChild(fragment.cloneNode(true));
+        this._algoBSelect.appendChild(fragment);
+    }
+
+    _bindEvents() {
+        this._enableCheckbox.addEventListener('change', this._onEnableChangeHandler);
+        this._algoASelect.addEventListener('change', this._onAlgoAChangeHandler);
+        this._algoBSelect.addEventListener('change', this._onAlgoBChangeHandler);
+    }
+
+    toggle() {
+        if (this._modal.style.display === 'block') {
+            this.close();
+        } else {
+            this.open();
+        }
+    }
+
+    open() {
+        this._modal.style.display = 'block';
+    }
+
+    close() {
+        this._modal.style.display = 'none';
+    }
+
+    _onEnableChange(enabled) {
+        this._active = enabled;
+        this._transitionManager.setDevModeActive(enabled);
+        
+        if (enabled) {
+            this._updateAlgos();
+            this._badge.style.display = 'block';
+            this._hud.displayMessage('DEV MODE ENABLED');
+        } else {
+            this._badge.style.display = 'none';
+            this._hud.displayMessage('DEV MODE DISABLED');
+        }
+    }
+
+    _onAlgoChange(slot, value) {
+        if (slot === 'A') {
+            this._algoA = value === '' ? null : algorithms[parseInt(value, 10)];
+        } else {
+            this._algoB = value === '' ? null : algorithms[parseInt(value, 10)];
+        }
+
+        if (this._active) {
+            this._updateAlgos();
+        }
+    }
+
+    _updateAlgos() {
+        this._transitionManager.setDevModeAlgos(this._algoA, this._algoB);
+    }
+
+    destroy() {
+        this._enableCheckbox.removeEventListener('change', this._onEnableChangeHandler);
+        this._algoASelect.removeEventListener('change', this._onAlgoAChangeHandler);
+        this._algoBSelect.removeEventListener('change', this._onAlgoBChangeHandler);
+    }
+}

--- a/src/KeyboardController.js
+++ b/src/KeyboardController.js
@@ -8,13 +8,13 @@ export default class KeyboardController {
      * @param {HUDController}     deps.hud
      * @param {TransitionManager} deps.transition
      * @param {MusicPlayer}       deps.musicPlayer
-     * @param {Object}            deps.spiral - Spiral instance (for devMode)
+     * @param {DevModeController} deps.devModeController
      */
-    constructor({ hud, transition, musicPlayer, spiral }) {
+    constructor({ hud, transition, musicPlayer, devModeController }) {
         this._hud = hud;
         this._transition = transition;
         this._musicPlayer = musicPlayer;
-        this._spiral = spiral;
+        this._devModeController = devModeController;
 
         this._handler = (e) => this._handleKeyup(e);
     }
@@ -34,9 +34,7 @@ export default class KeyboardController {
         switch (e.code) {
             case 'Space':
                 e.preventDefault();
-                if (!this._spiral.devMode) {
-                    this._transition.changeAlgorithm();
-                }
+                this._transition.changeAlgorithm();
                 break;
 
             case 'KeyF':
@@ -44,7 +42,6 @@ export default class KeyboardController {
                 break;
 
             case 'KeyI':
-                if (this._spiral.devMode) break;
                 this._transition.autoChange = Math.min(
                     this._transition.autoChange + 10,
                     300,
@@ -55,7 +52,6 @@ export default class KeyboardController {
                 break;
 
             case 'KeyD':
-                if (this._spiral.devMode) break;
                 this._transition.autoChange = Math.max(
                     this._transition.autoChange - 10,
                     10,
@@ -66,7 +62,6 @@ export default class KeyboardController {
                 break;
 
             case 'KeyM':
-                if (this._spiral.devMode) break;
                 this._transition.manual = !this._transition.manual;
                 this._hud.displayMessage(
                     this._transition.manual ? 'Manual mode' : 'Auto mode',
@@ -86,6 +81,10 @@ export default class KeyboardController {
 
             case 'KeyP':
                 this._musicPlayer.togglePlayerVisibility();
+                break;
+
+            case 'KeyE':
+                this._devModeController.toggle();
                 break;
 
             default:

--- a/src/Spiral.js
+++ b/src/Spiral.js
@@ -1,5 +1,6 @@
 import AlgorithmChooser from './AlgorithmChooser.js';
 import AlgorithmLoader from './AlgorithmLoader.js';
+import DevModeController from './DevModeController.js';
 import HUDController from './HUDController.js';
 import KeyboardController from './KeyboardController.js';
 import MusicPlayer from './MusicPlayer.js';
@@ -7,31 +8,22 @@ import TransitionManager from './TransitionManager.js';
 import FrequencyAnalyser from './utils/FrequencyAnalyser.js';
 
 export default class Spiral {
-    constructor(options = {}) {
-        // Setup canvas
+    constructor() {
         this.canvas = document.querySelector('#canvas');
         this.ctx = this.canvas.getContext('2d');
         this.w = window.innerWidth;
         this.h = window.innerHeight;
         this._applyDpr();
 
-        this.devMode = options.devMode === true;
-        this.devAlgorithmClass = options.devAlgorithmClass || null;
-
-        // Algorithm loader instance
         this.algorithmLoader = new AlgorithmLoader(this.ctx, this.w, this.h);
-
-        // Algorithm chooser instance
         this.algorithmChooser = new AlgorithmChooser();
 
-        // HUD controller
         this.hud = new HUDController({
             messageElement: document.querySelector('#msg'),
             algosDisplayElement: document.querySelector('#algos'),
             helpElement: document.querySelector('#help'),
         });
 
-        // Transition manager
         this.transitionManager = new TransitionManager({
             canvas: this.canvas,
             ctx: this.ctx,
@@ -39,23 +31,19 @@ export default class Spiral {
             algorithmChooser: this.algorithmChooser,
             hud: this.hud,
             getDimensions: () => ({ w: this.w, h: this.h }),
-            devMode: this.devMode,
-            devAlgorithmClass: this.devAlgorithmClass,
         });
 
-        // Music player and frequency analyser — deferred to init()
+        this.devModeController = new DevModeController({
+            transitionManager: this.transitionManager,
+            hud: this.hud,
+        });
+
         this.musicPlayer = null;
         this.frequencyAnalyser = null;
-
-        // Keyboard controller — deferred to init() (needs musicPlayer)
         this.keyboardController = null;
-
-        // Cursor hide timeout ID for debouncing
         this.cursorHideTimeout = null;
-        // Resize debounce timeout ID
         this.resizeTimeout = null;
 
-        // Initialize the application
         this.init();
     }
 
@@ -102,7 +90,7 @@ export default class Spiral {
             hud: this.hud,
             transition: this.transitionManager,
             musicPlayer: this.musicPlayer,
-            spiral: this,
+            devModeController: this.devModeController,
         });
         this.keyboardController.bind();
     }
@@ -173,8 +161,8 @@ export default class Spiral {
         this._welcomeTimers.forEach(clearTimeout);
         this.hud.destroy();
         this.musicPlayer.destroy();
+        this.devModeController.destroy();
 
-        // clear pending timeouts created by Spiral (cursor hide + resize debounce)
         if (this.cursorHideTimeout) {
             clearTimeout(this.cursorHideTimeout);
         }

--- a/src/TransitionManager.js
+++ b/src/TransitionManager.js
@@ -13,8 +13,6 @@ export default class TransitionManager {
      * @param {AlgorithmChooser}         deps.algorithmChooser
      * @param {HUDController}            deps.hud
      * @param {Function}                 deps.getDimensions  - Returns { w, h }
-     * @param {boolean}                  deps.devMode
-     * @param {Function|null}            deps.devAlgorithmClass
      */
     constructor({
         canvas,
@@ -23,8 +21,6 @@ export default class TransitionManager {
         algorithmChooser,
         hud,
         getDimensions,
-        devMode,
-        devAlgorithmClass,
     }) {
         this._canvas = canvas;
         this._ctx = ctx;
@@ -32,8 +28,6 @@ export default class TransitionManager {
         this._algorithmChooser = algorithmChooser;
         this._hud = hud;
         this._getDimensions = getDimensions;
-        this._devMode = devMode;
-        this._devAlgorithmClass = devAlgorithmClass;
 
         this._currentAlgorithm = null;
         this._regen = null;
@@ -41,6 +35,11 @@ export default class TransitionManager {
         this._manual = false;
         this._isTransitioning = false;
         this._algoRetries = 0;
+
+        this._devModeActive = false;
+        this._devModeAlgoA = null;
+        this._devModeAlgoB = null;
+        this._devModeAlternator = 0;
     }
 
     /** The currently running algorithm instance (read-only). */
@@ -81,7 +80,7 @@ export default class TransitionManager {
         clearInterval(this._regen);
         this._regen = null;
 
-        if (!this._manual && !this._devMode) {
+        if (!this._manual) {
             this._regen = setInterval(() => {
                 this.changeAlgorithm();
             }, this._autoChange * 1000);
@@ -90,7 +89,6 @@ export default class TransitionManager {
 
     /** Trigger a full algorithm transition. */
     changeAlgorithm() {
-        if (this._devMode) return;
         if (this._isTransitioning) return;
         this._isTransitioning = true;
 
@@ -192,18 +190,15 @@ export default class TransitionManager {
     /** Pick a random algorithm, instantiate it, handle errors with retry. */
     _chooseAlgos() {
         const { w, h } = this._getDimensions();
-        let AlgorithmClass = this._algorithmChooser.getRandomAlgorithm();
+        let AlgorithmClass;
 
-        if (this._devMode) {
-            if (
-                !this._devAlgorithmClass ||
-                typeof this._devAlgorithmClass !== 'function'
-            ) {
-                throw new Error(
-                    'Dev mode enabled but no devAlgorithmClass provided.',
-                );
-            }
-            AlgorithmClass = this._devAlgorithmClass;
+        if (this._devModeActive) {
+            const isSlotA = this._devModeAlternator === 0;
+            this._devModeAlternator = 1 - this._devModeAlternator;
+            const algoChoice = isSlotA ? this._devModeAlgoA : this._devModeAlgoB;
+            AlgorithmClass = algoChoice || this._algorithmChooser.getRandomAlgorithm();
+        } else {
+            AlgorithmClass = this._algorithmChooser.getRandomAlgorithm();
         }
 
         try {
@@ -217,8 +212,6 @@ export default class TransitionManager {
             );
             this._algoRetries++;
             if (this._algoRetries < 3) {
-                // Retry directly (not via changeAlgorithm which has
-                // the _isTransitioning guard active during this call)
                 this._chooseAlgos();
             } else {
                 console.error(
@@ -227,5 +220,17 @@ export default class TransitionManager {
                 this._algoRetries = 0;
             }
         }
+    }
+
+    /** Enable or disable dev mode. */
+    setDevModeActive(active) {
+        this._devModeActive = active;
+        this._devModeAlternator = 0;
+    }
+
+    /** Set the algorithms for dev mode (null = random). */
+    setDevModeAlgos(algoA, algoB) {
+        this._devModeAlgoA = algoA;
+        this._devModeAlgoB = algoB;
     }
 }

--- a/style.css
+++ b/style.css
@@ -306,6 +306,105 @@ progress::-webkit-progress-value {
     letter-spacing: 0.04em;
 }
 
+#dev-mode {
+    position: absolute;
+    top: 1em;
+    right: 1em;
+    z-index: 3;
+    background: rgba(0, 0, 0, 0.9);
+    padding: 1.5em 2em;
+    font-family: 'Oswald', sans-serif;
+    width: auto;
+    min-width: 320px;
+    max-width: 400px;
+    text-align: center;
+    display: none;
+    border: 1px solid #333;
+    border-radius: 8px;
+}
+
+#dev-mode h3 {
+    margin: 0 0 1em 0;
+    color: orangered;
+    font-size: 1.2em;
+    letter-spacing: 2px;
+}
+
+#dev-mode label {
+    display: flex;
+    align-items: center;
+    gap: 0.5em;
+    cursor: pointer;
+    color: #ccc;
+    font-size: 0.95em;
+}
+
+#dev-mode .dev-row {
+    justify-content: center;
+    margin-bottom: 1em;
+}
+
+#dev-mode .dev-row span {
+    color: white;
+}
+
+#dev-mode input[type='checkbox'] {
+    width: 18px;
+    height: 18px;
+    accent-color: orangered;
+    cursor: pointer;
+}
+
+#dev-mode .dev-selects {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75em;
+    margin-bottom: 1em;
+}
+
+#dev-mode .dev-selects label {
+    justify-content: space-between;
+}
+
+#dev-mode select {
+    background: #222;
+    color: white;
+    border: 1px solid #444;
+    padding: 0.4em 0.5em;
+    font-family: 'DM Mono', monospace;
+    font-size: 0.8em;
+    cursor: pointer;
+    min-width: 160px;
+    border-radius: 4px;
+}
+
+#dev-mode select:focus {
+    outline: none;
+    border-color: orangered;
+}
+
+#dev-mode .dev-hint {
+    color: #666;
+    font-size: 0.75em;
+    margin: 0;
+    letter-spacing: 0;
+}
+
+#dev-badge {
+    position: absolute;
+    top: 1em;
+    left: 1em;
+    background: orangered;
+    color: white;
+    font-family: 'Oswald', sans-serif;
+    font-size: 0.7em;
+    padding: 0.3em 0.6em;
+    border-radius: 3px;
+    letter-spacing: 1px;
+    z-index: 2;
+    display: none;
+}
+
 @media (max-width: 545px) {
     #picker {
         display: flex;

--- a/style.css
+++ b/style.css
@@ -308,8 +308,8 @@ progress::-webkit-progress-value {
 
 #dev-mode {
     position: absolute;
-    top: 1em;
-    right: 1em;
+    bottom: 1em;
+    left: 1em;
     z-index: 3;
     background: rgba(0, 0, 0, 0.9);
     padding: 1.5em 2em;
@@ -392,8 +392,8 @@ progress::-webkit-progress-value {
 
 #dev-badge {
     position: absolute;
-    top: 1em;
-    left: 1em;
+    bottom: 1em;
+    right: 1em;
     background: orangered;
     color: white;
     font-family: 'Oswald', sans-serif;


### PR DESCRIPTION
## Changes

- Add `DevModeController` with modal UI for selecting algorithm pairs
- Press `E` to toggle dev mode modal (top-right corner)
- Algorithm A and B selectors with "Random" default option
- DEV badge appears when mode is active
- Transitions alternate between A and B; "Random" picks new algo each time
- Reuses existing controls: I/D for interval, M for manual mode, Space for trigger
- Remove hardcoded `devMode` and `devAlgorithmClass` from `renderer.js` and `TransitionManager`

## Issue

Closes #88

## Testing

- [x] Tested in `pnpm start`
- [x] No console errors
- [x] Pressing E opens/closes modal
- [x] DEV badge appears when enabled
- [x] Algorithm selectors populate correctly
- [x] I/D/M/Space work identically in dev mode

## Checklist

- [x] Code follows [AGENTS.md](AGENTS.md) conventions
- [x] CHANGELOG.md updated
- [x] Related files updated (KeyboardController, Spiral, TransitionManager, index.html, style.css)