### PR TITLE
fix: restrict Dev Mode to development only

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,14 +25,14 @@ See [WORKFLOW.md](WORKFLOW.md) for the complete workflow and decision points.
 
 ## Tech Stack
 
-| Layer           | Technology        | Notes                                        |
-| --------------- | ----------------- | -------------------------------------------- |
-| Desktop shell   | Electron v40      | ESM (`"type": "module"`)                     |
-| Rendering       | HTML5 Canvas 2D   | No WebGL                                     |
-| Animation lib   | GSAP              | Loaded from `assets/js/gsap.min.js`, not npm |
-| Fonts           | DM Mono, Oswald   | Custom TTFs in `assets/fonts/`               |
-| Package manager | pnpm              | Required — do not use npm/yarn               |
-| Packaging       | @electron/packager | Dev dependency                              |
+| Layer           | Technology         | Notes                                        |
+| --------------- | ------------------ | -------------------------------------------- |
+| Desktop shell   | Electron v40       | ESM (`"type": "module"`)                     |
+| Rendering       | HTML5 Canvas 2D    | No WebGL                                     |
+| Animation lib   | GSAP               | Loaded from `assets/js/gsap.min.js`, not npm |
+| Fonts           | DM Mono, Oswald    | Custom TTFs in `assets/fonts/`               |
+| Package manager | pnpm               | Required — do not use npm/yarn               |
+| Packaging       | @electron/packager | Dev dependency                               |
 
 No TypeScript. No bundler. No test framework. No linter/formatter config.
 
@@ -80,26 +80,26 @@ assets/
 
 ## File Structure Map
 
-| Path                      | Purpose                                                                                  |
-| ------------------------- | ---------------------------------------------------------------------------------------- |
-| `main.js`                 | Electron main process entry                                                              |
-| `preload.js`              | Context bridge, version injection                                                        |
-| `renderer.js`             | Renderer entry: imports polyfills, instantiates Spiral                                   |
-| `index.html`              | DOM structure: canvas, HUD, player controls, dev mode modal                              |
-| `style.css`               | All styles                                                                               |
-| `src/Spiral.js`              | Orchestrator — canvas, DPR, resize, cursor; wires all modules                         |
-| `src/HUDController.js`      | HUD overlay — messages, algorithm name, silent mode, help toggle                      |
-| `src/KeyboardController.js` | Centralized keyboard shortcuts (Space, F, I, D, M, S, H, P, E)                        |
-| `src/TransitionManager.js`  | Algorithm lifecycle, canvas context reset, auto-change timer, dev mode cycling        |
-| `src/DevModeController.js`  | Dev mode modal — algorithm pair selection for testing transitions                      |
-| `src/MusicPlayer.js`        | Audio playback, playlist, progress bar                                                |
-| `src/AlgorithmChooser.js`   | Algorithm registry and random picker                                                  |
-| `src/AlgorithmLoader.js`    | Base class for algorithms                                                             |
-| `src/algos/*.js`          | Individual algorithm classes (141 files)                                                 |
-| `src/utils/*.js`          | Shared utilities (Vector, Particle, math, random, roundRect polyfill, FrequencyAnalyser) |
-| `src/generated/`          | Auto-generated algorithm registry (algorithmRegistry.js)                                 |
-| `assets/js/`              | GSAP (loaded globally, not via npm)                                                      |
-| `assets/fonts/`           | Custom font files                                                                        |
+| Path                        | Purpose                                                                                                              |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `main.js`                   | Electron main process entry                                                                                          |
+| `preload.js`                | Context bridge, version injection                                                                                    |
+| `renderer.js`               | Renderer entry: imports polyfills, instantiates Spiral                                                               |
+| `index.html`                | DOM structure: canvas, HUD, player controls, dev mode modal                                                          |
+| `style.css`                 | All styles                                                                                                           |
+| `src/Spiral.js`             | Orchestrator — canvas, DPR, resize, cursor; wires all modules                                                        |
+| `src/HUDController.js`      | HUD overlay — messages, algorithm name, silent mode, help toggle                                                     |
+| `src/KeyboardController.js` | Centralized keyboard shortcuts (Space, F, I, D, M, S, H, P, E)                                                       |
+| `src/TransitionManager.js`  | Algorithm lifecycle, canvas context reset, auto-change timer, dev mode cycling                                       |
+| `src/DevModeController.js`  | Dev mode modal — algorithm pair selection for testing transitions (**hidden and inaccessible in production builds**) |
+| `src/MusicPlayer.js`        | Audio playback, playlist, progress bar                                                                               |
+| `src/AlgorithmChooser.js`   | Algorithm registry and random picker                                                                                 |
+| `src/AlgorithmLoader.js`    | Base class for algorithms                                                                                            |
+| `src/algos/*.js`            | Individual algorithm classes (141 files)                                                                             |
+| `src/utils/*.js`            | Shared utilities (Vector, Particle, math, random, roundRect polyfill, FrequencyAnalyser)                             |
+| `src/generated/`            | Auto-generated algorithm registry (algorithmRegistry.js)                                                             |
+| `assets/js/`                | GSAP (loaded globally, not via npm)                                                                                  |
+| `assets/fonts/`             | Custom font files                                                                                                    |
 
 ## Code Conventions
 
@@ -169,7 +169,8 @@ assets/
 - All keyboard shortcuts are centralized in `KeyboardController.js` — modify
   shortcuts there (Space, F, I, D, M, S, H, P, E)
 - Dev mode (press E) allows testing algorithm transitions — it cycles between
-  two selectable algorithms (or random) and reuses the same interval/manual controls
+  two selectable algorithms (or random) and reuses the same interval/manual
+  controls. **Dev mode is hidden and inaccessible in production builds.**
 - GSAP is **global** (`window.gsap`) from the vendored file — `AlgorithmLoader`
   exposes it as a static ref
 - `FrequencyAnalyser` is instantiated once in `Spiral.js` init —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,19 @@
 
 ## 2026-02-22
 
+- fix: Restrict Dev Mode (algorithm test modal, badge, and shortcut) to
+  development only — all Dev Mode UI and logic are now inaccessible in
+  production builds; enforced via environment flag and renderer checks
+
 - feat: Add runtime dev mode for algorithm testing — modal with algorithm pair
-  selectors (press E), visual DEV badge, reuses existing interval/manual controls;
-  replaces hardcoded dev mode in renderer.js
-- feat: Add playlist accordion with track-jump to music player — current track name and chevron toggle displayed in player bar; clicking chevron opens/closes animated accordion showing full playlist; clicking a track jumps to it with a 200ms delay (debounced)
-- feat: Add elapsed/remaining and total time display to music player progress bar
+  selectors (press E), visual DEV badge, reuses existing interval/manual
+  controls; replaces hardcoded dev mode in renderer.js
+- feat: Add playlist accordion with track-jump to music player — current track
+  name and chevron toggle displayed in player bar; clicking chevron opens/closes
+  animated accordion showing full playlist; clicking a track jumps to it with a
+  200ms delay (debounced)
+- feat: Add elapsed/remaining and total time display to music player progress
+  bar
 - refactor: Extract HUDController, KeyboardController, and TransitionManager
   from Spiral.js — reduce god object from ~375 to ~200 lines by splitting HUD
   overlay, keyboard shortcuts, and algorithm lifecycle into focused modules
@@ -17,9 +25,9 @@
   miterLimit, imageSmoothingEnabled, direction) to prevent state leakage
 - fix: Add re-entrancy guard to algorithm transitions — prevent overlapping
   transitions from rapid input or timer races
-- refactor: Centralize all keyboard shortcuts in KeyboardController — consolidate
-  handlers from Spiral.js and MusicPlayer.js into single module with destroy()
-  cleanup
+- refactor: Centralize all keyboard shortcuts in KeyboardController —
+  consolidate handlers from Spiral.js and MusicPlayer.js into single module with
+  destroy() cleanup
 
 ## 2026-02-19
 
@@ -34,8 +42,9 @@
   add aria-label and title attributes for screen reader support
 - refactor: Replace canvas.click() with direct method calls — decouple algorithm
   transition logic from DOM events by extracting changeAlgorithm() method
-- refactor: Deduplicate stopCurrentAlgorithm() calls — remove redundant calls from
-  clearMethod() and chooseAlgos(), keeping only the call in changeAlgorithm()
+- refactor: Deduplicate stopCurrentAlgorithm() calls — remove redundant calls
+  from clearMethod() and chooseAlgos(), keeping only the call in
+  changeAlgorithm()
 - refactor: Consolidate duplicate random/randomColor implementations — make
   AlgorithmLoader delegate to randomUtils.js for single source of truth
 

--- a/index.html
+++ b/index.html
@@ -25,16 +25,24 @@
             <div class="dev-selects">
                 <label>
                     <span>Algorithm A:</span>
-                    <select id="dev-algo-a"><option value="">Random</option></select>
+                    <select id="dev-algo-a"
+                        ><option value="">Random</option></select
+                    >
                 </label>
                 <label>
                     <span>Algorithm B:</span>
-                    <select id="dev-algo-b"><option value="">Random</option></select>
+                    <select id="dev-algo-b"
+                        ><option value="">Random</option></select
+                    >
                 </label>
             </div>
-            <p class="dev-hint">I/D = interval, M = manual mode, Space = trigger</p>
+            <p class="dev-hint"
+                >I/D = interval, M = manual mode, Space = trigger</p
+            >
         </div>
+
         <div id="dev-badge">DEV</div>
+
         <div id="help">
             <div>
                 <h1>THE SPIRAL</h1>
@@ -235,10 +243,13 @@
                 </div>
             </div>
             <div id="playlist-accordion">
-            <ol id="playlist"></ol>
-        </div>
-        <div id="progress">
-                <span id="time-elapsed" title="Click to toggle remaining time"></span>
+                <ol id="playlist"></ol>
+            </div>
+            <div id="progress">
+                <span
+                    id="time-elapsed"
+                    title="Click to toggle remaining time"
+                ></span>
                 <progress
                     id="progress-percent"
                     max="100"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "scripts": {
         "generate:algos": "node scripts/generate-algorithm-registry.mjs",
         "prestart": "pnpm generate:algos",
-        "start": "electron ."
+        "start": "NODE_ENV=development electron .",
+        "start:prod": "NODE_ENV=production electron ."
     },
     "keywords": [
         "music",

--- a/preload.js
+++ b/preload.js
@@ -5,3 +5,8 @@ contextBridge.exposeInMainWorld('versions', {
     chrome: process.versions.chrome,
     electron: process.versions.electron,
 });
+
+// Expose isDev flag to renderer
+contextBridge.exposeInMainWorld('env', {
+    isDev: process.env.NODE_ENV === 'development',
+});

--- a/src/DevModeController.js
+++ b/src/DevModeController.js
@@ -5,6 +5,7 @@ export default class DevModeController {
         this._transitionManager = transitionManager;
         this._hud = hud;
 
+        this._isDev = window.env?.isDev;
         this._modal = document.querySelector('#dev-mode');
         this._enableCheckbox = document.querySelector('#dev-enable');
         this._algoASelect = document.querySelector('#dev-algo-a');
@@ -15,17 +16,26 @@ export default class DevModeController {
         this._algoA = null;
         this._algoB = null;
 
-        this._onEnableChangeHandler = (e) => this._onEnableChange(e.target.checked);
-        this._onAlgoAChangeHandler = (e) => this._onAlgoChange('A', e.target.value);
-        this._onAlgoBChangeHandler = (e) => this._onAlgoChange('B', e.target.value);
+        this._onEnableChangeHandler = (e) =>
+            this._onEnableChange(e.target.checked);
+        this._onAlgoAChangeHandler = (e) =>
+            this._onAlgoChange('A', e.target.value);
+        this._onAlgoBChangeHandler = (e) =>
+            this._onAlgoChange('B', e.target.value);
 
-        this._populateSelects();
-        this._bindEvents();
+        if (this._isDev) {
+            this._populateSelects();
+            this._bindEvents();
+        } else {
+            // Hide modal and badge in production
+            if (this._modal) this._modal.style.display = 'none';
+            if (this._badge) this._badge.style.display = 'none';
+        }
     }
 
     _populateSelects() {
         const fragment = document.createDocumentFragment();
-        
+
         algorithms.forEach((AlgoClass, index) => {
             const option = document.createElement('option');
             option.value = index;
@@ -38,9 +48,18 @@ export default class DevModeController {
     }
 
     _bindEvents() {
-        this._enableCheckbox.addEventListener('change', this._onEnableChangeHandler);
-        this._algoASelect.addEventListener('change', this._onAlgoAChangeHandler);
-        this._algoBSelect.addEventListener('change', this._onAlgoBChangeHandler);
+        this._enableCheckbox.addEventListener(
+            'change',
+            this._onEnableChangeHandler,
+        );
+        this._algoASelect.addEventListener(
+            'change',
+            this._onAlgoAChangeHandler,
+        );
+        this._algoBSelect.addEventListener(
+            'change',
+            this._onAlgoBChangeHandler,
+        );
     }
 
     toggle() {
@@ -62,7 +81,7 @@ export default class DevModeController {
     _onEnableChange(enabled) {
         this._active = enabled;
         this._transitionManager.setDevModeActive(enabled);
-        
+
         if (enabled) {
             this._updateAlgos();
             this._badge.style.display = 'block';
@@ -90,8 +109,17 @@ export default class DevModeController {
     }
 
     destroy() {
-        this._enableCheckbox.removeEventListener('change', this._onEnableChangeHandler);
-        this._algoASelect.removeEventListener('change', this._onAlgoAChangeHandler);
-        this._algoBSelect.removeEventListener('change', this._onAlgoBChangeHandler);
+        this._enableCheckbox.removeEventListener(
+            'change',
+            this._onEnableChangeHandler,
+        );
+        this._algoASelect.removeEventListener(
+            'change',
+            this._onAlgoAChangeHandler,
+        );
+        this._algoBSelect.removeEventListener(
+            'change',
+            this._onAlgoBChangeHandler,
+        );
     }
 }

--- a/src/KeyboardController.js
+++ b/src/KeyboardController.js
@@ -16,6 +16,8 @@ export default class KeyboardController {
         this._musicPlayer = musicPlayer;
         this._devModeController = devModeController;
 
+        // Only enable dev mode shortcut if allowed
+        this._isDev = window.env?.isDev;
         this._handler = (e) => this._handleKeyup(e);
     }
 
@@ -84,7 +86,9 @@ export default class KeyboardController {
                 break;
 
             case 'KeyE':
-                this._devModeController.toggle();
+                if (this._isDev) {
+                    this._devModeController.toggle();
+                }
                 break;
 
             default:


### PR DESCRIPTION
Restricts Dev Mode (algorithm test modal, badge, and shortcut) to development only. All Dev Mode UI and logic are now inaccessible in production builds, enforced via environment flag and renderer checks.\n\nCloses #92.