### PR TITLE
fix: remove developer mode instructions from help screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,10 +97,6 @@
                     </span>
                 </p>
                 <p>
-                    <span class="keys">Press E for dev mode</span> to test
-                    specific algorithms and transitions.
-                </p>
-                <p>
                     <span class="help">H to open / close the help screen.</span>
                 </p>
             </div>


### PR DESCRIPTION
closes #98