### PR TITLE
Add hotkey summary to help modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 <!-- Format: ## YYYY-MM-DD followed by one-liner entries. -->
 
+## 2026-02-28
+
+- feat: Add hotkey summary to help modal — quick boxed hotkey overview between
+  the heading and help text (index.html, style.css)
+
 ## 2026-02-22
 
 - fix: Restrict Dev Mode (algorithm test modal, badge, and shortcut) to

--- a/index.html
+++ b/index.html
@@ -48,6 +48,40 @@
                 <h1>THE SPIRAL</h1>
                 <h4>Music Player / Visualizer v1.0.0</h4>
                 <h3>HELP SCREEN</h3>
+                <div class="hotkey-summary" aria-hidden="true">
+                    <span class="hotkey"
+                        ><span class="key">Space</span
+                        ><span class="label">New spiral</span></span
+                    >
+                    <span class="hotkey"
+                        ><span class="key">F</span
+                        ><span class="label">Full-screen</span></span
+                    >
+                    <span class="hotkey"
+                        ><span class="key">P</span
+                        ><span class="label">Player</span></span
+                    >
+                    <span class="hotkey"
+                        ><span class="key">I</span
+                        ><span class="label">+10s Interval</span></span
+                    >
+                    <span class="hotkey"
+                        ><span class="key">D</span
+                        ><span class="label">-10s Interval</span></span
+                    >
+                    <span class="hotkey"
+                        ><span class="key">M</span
+                        ><span class="label">Auto/Manual</span></span
+                    >
+                    <span class="hotkey"
+                        ><span class="key">S</span
+                        ><span class="label">Silence</span></span
+                    >
+                    <span class="hotkey"
+                        ><span class="key">H</span
+                        ><span class="label">Help</span></span
+                    >
+                </div>
             </div>
             <div class="text">
                 <p>

--- a/style.css
+++ b/style.css
@@ -61,6 +61,49 @@ canvas {
     display: none;
 }
 
+/* Hotkey summary (compact boxed keycaps shown between heading and help text) */
+.hotkey-summary {
+    display: flex;
+    justify-content: center;
+    background-color: black;
+    gap: 0.6rem;
+    flex-wrap: wrap;
+    margin: 1.5rem 0;
+}
+.hotkey {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    color: #ddd;
+    font-size: 0.95em;
+    text-transform: uppercase;
+}
+.hotkey .key {
+    display: inline-block;
+    background: rgba(255, 255, 255, 0.1);
+    color: #fff;
+    padding: 0.18rem 0.4rem;
+    border-radius: 4px;
+    font-weight: 700;
+    box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.05) inset;
+}
+.hotkey .label {
+    color: orange;
+    font-size: 0.9em;
+}
+
+@media (max-width: 480px) {
+    .hotkey-summary {
+        gap: 0.45rem;
+    }
+    .hotkey {
+        font-size: 0.9em;
+    }
+    .hotkey .label {
+        display: none;
+    }
+}
+
 h1 {
     margin-bottom: 0;
     color: orangered;
@@ -171,7 +214,9 @@ input[type='file'] {
     padding: 0 0.1em;
     line-height: 0;
     flex-shrink: 0;
-    transition: color 0.2s, transform 0.35s ease;
+    transition:
+        color 0.2s,
+        transform 0.35s ease;
     outline: none;
     display: none;
 }
@@ -199,7 +244,9 @@ input[type='file'] {
     overflow: hidden;
     max-height: 0;
     opacity: 0;
-    transition: max-height 0.35s ease, opacity 0.3s ease;
+    transition:
+        max-height 0.35s ease,
+        opacity 0.3s ease;
 }
 
 #playlist-accordion.open {


### PR DESCRIPTION
Closes #103\n\nThis adds a compact, boxed hotkey overview to the help modal so users can quickly see available shortcuts at a glance. Files changed: index.html (markup), style.css (styles), CHANGELOG.md (entry). No JS behavior changed.\n\nManual verification: open app and press H to open help; the hotkey summary appears between the HELP SCREEN heading and the long help text.\n