### PR TITLE
refactor: Make canvas ctx/w/h static on AlgorithmLoader (closes #138)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - refactor: Move AlgorithmChooser logic into TransitionManager — removes standalone AlgorithmChooser class, adds getRandomAlgorithm() method with lastAlgos history tracking to TransitionManager; updates tests accordingly
 
+- refactor: Make canvas context, width, and height static properties on AlgorithmLoader — eliminates ctx/w/h constructor params from all 143 algorithms; values auto-update on resize (closes #138)
+
 ## 2026-03-02
 
 - chore: Add unit tests for WaveformController (0%→100%) — 17 tests covering constructor, \_resizeCanvas, toggle, \_start, \_stop, destroy, \_draw (including exponential-smoothing assertion), and getWaveformData; total test count 260→277

--- a/__tests__/AlgorithmLoader.test.js
+++ b/__tests__/AlgorithmLoader.test.js
@@ -33,14 +33,17 @@ class BrokenAlgo extends AlgorithmLoader {
 }
 
 describe('algorithmLoader', () => {
+    beforeEach(() => {
+        const { ctx } = createMockCtx();
+        AlgorithmLoader.ctx = ctx;
+        AlgorithmLoader.w = 100;
+        AlgorithmLoader.h = 200;
+    });
+
     describe('constructor', () => {
         it('initialises state correctly', () => {
-            const { ctx } = createMockCtx();
-            const algo = new WorkingAlgo(ctx, 100, 200);
+            const algo = new WorkingAlgo();
 
-            expect(algo.ctx).toBe(ctx);
-            expect(algo.w).toBe(100);
-            expect(algo.h).toBe(200);
             expect(algo.t).toBe(0);
             expect(algo.isRunning).toBeTruthy();
             expect(algo.animationFrameId).toBeNull();
@@ -49,16 +52,14 @@ describe('algorithmLoader', () => {
 
     describe('stop', () => {
         it('sets isRunning to false', () => {
-            const { ctx } = createMockCtx();
-            const algo = new WorkingAlgo(ctx, 100, 100);
+            const algo = new WorkingAlgo();
             algo.stop();
 
             expect(algo.isRunning).toBeFalsy();
         });
 
         it('clears animationFrameId', () => {
-            const { ctx } = createMockCtx();
-            const algo = new WorkingAlgo(ctx, 100, 100);
+            const algo = new WorkingAlgo();
             algo.animationFrameId = 42;
             algo.stop();
 
@@ -69,7 +70,8 @@ describe('algorithmLoader', () => {
     describe('draw error handling', () => {
         it('dispatches algorithm-error on the canvas when draw throws', () => {
             const { canvas, ctx } = createMockCtx();
-            const algo = new BrokenAlgo(ctx, 100, 100);
+            AlgorithmLoader.ctx = ctx;
+            const algo = new BrokenAlgo();
 
             const handler = vi.fn();
             canvas.addEventListener('algorithm-error', handler);
@@ -80,22 +82,20 @@ describe('algorithmLoader', () => {
         });
 
         it('stops the algorithm after a draw error', () => {
-            const { ctx } = createMockCtx();
-            const algo = new BrokenAlgo(ctx, 100, 100);
+            const algo = new BrokenAlgo();
             algo.draw();
 
             expect(algo.isRunning).toBeFalsy();
         });
 
         it('skips draw when isRunning is false', () => {
-            const { ctx } = createMockCtx();
             const drawSpy = vi.fn();
             class SpyAlgo extends AlgorithmLoader {
                 draw() {
                     drawSpy();
                 }
             }
-            const algo = new SpyAlgo(ctx, 100, 100);
+            const algo = new SpyAlgo();
             algo.stop();
             algo.draw();
 
@@ -146,7 +146,8 @@ describe('algorithmLoader', () => {
     describe('base draw throws when not overridden', () => {
         it('dispatches algorithm-error because base draw throws', () => {
             const { canvas, ctx } = createMockCtx();
-            const algo = new AlgorithmLoader(ctx, 100, 100);
+            AlgorithmLoader.ctx = ctx;
+            const algo = new AlgorithmLoader();
 
             const handler = vi.fn();
             canvas.addEventListener('algorithm-error', handler);
@@ -211,8 +212,7 @@ describe('algorithmLoader', () => {
 
     describe('canvas instance methods', () => {
         it('requestFrame schedules draw via requestAnimationFrame', () => {
-            const { ctx } = createMockCtx();
-            const algo = new WorkingAlgo(ctx, 100, 100);
+            const algo = new WorkingAlgo();
             const spy = vi.spyOn(globalThis, 'requestAnimationFrame');
             algo.requestFrame();
 
@@ -223,7 +223,8 @@ describe('algorithmLoader', () => {
             const { canvas, ctx } = createMockCtx();
             canvas.width = 100;
             canvas.height = 100;
-            const algo = new WorkingAlgo(ctx, 100, 100);
+            AlgorithmLoader.ctx = ctx;
+            const algo = new WorkingAlgo();
             algo.clearScreen();
 
             expect(ctx.save).toHaveBeenCalledOnce();
@@ -236,7 +237,8 @@ describe('algorithmLoader', () => {
             const { canvas, ctx } = createMockCtx();
             canvas.width = 100;
             canvas.height = 100;
-            const algo = new WorkingAlgo(ctx, 100, 100);
+            AlgorithmLoader.ctx = ctx;
+            const algo = new WorkingAlgo();
             algo.fillScreen();
 
             expect(ctx.save).toHaveBeenCalledOnce();
@@ -247,7 +249,10 @@ describe('algorithmLoader', () => {
 
         it('rotateCanvasRadians translates to center, rotates, then translates back', () => {
             const { ctx } = createMockCtx();
-            const algo = new WorkingAlgo(ctx, 100, 100);
+            AlgorithmLoader.ctx = ctx;
+            AlgorithmLoader.w = 100;
+            AlgorithmLoader.h = 100;
+            const algo = new WorkingAlgo();
             algo.rotateCanvasRadians(Math.PI);
 
             expect(ctx.translate).toHaveBeenNthCalledWith(1, 50, 50);
@@ -257,7 +262,10 @@ describe('algorithmLoader', () => {
 
         it('rotateCanvasDegrees converts degrees to radians before rotating', () => {
             const { ctx } = createMockCtx();
-            const algo = new WorkingAlgo(ctx, 100, 100);
+            AlgorithmLoader.ctx = ctx;
+            AlgorithmLoader.w = 100;
+            AlgorithmLoader.h = 100;
+            const algo = new WorkingAlgo();
             algo.rotateCanvasDegrees(90);
 
             expect(ctx.rotate).toHaveBeenCalledWith(Math.PI / 2);

--- a/__tests__/TransitionManager.test.js
+++ b/__tests__/TransitionManager.test.js
@@ -1,6 +1,7 @@
 // oxlint-disable max-classes-per-file
 // oxlint-disable no-empty-function
 
+import AlgorithmLoader from '../src/AlgorithmLoader.js';
 import TransitionManager from '../src/TransitionManager.js';
 import createMockCanvas from './helpers/mockCanvas.js';
 
@@ -30,13 +31,16 @@ vi.mock(import('../src/generated/algorithmRegistry.js'), () => ({
 }));
 
 function createDeps(overrides = {}) {
-    const { canvas } = createMockCanvas();
+    const { canvas, ctx } = createMockCanvas();
     const mockHud = { displayAlgorithmName: vi.fn() };
+
+    AlgorithmLoader.ctx = ctx;
+    AlgorithmLoader.w = 1920;
+    AlgorithmLoader.h = 1080;
 
     return {
         algorithmLoader: { speed: 0 },
         canvas,
-        getDimensions: () => ({ h: 1080, w: 1920 }),
         hudController: mockHud,
         ...overrides,
     };
@@ -268,10 +272,11 @@ describe('transitionManager', () => {
             // Patch globalThis.devicePixelRatio for DPR scaling
             globalThis.devicePixelRatio = 2;
 
+            AlgorithmLoader.ctx = ctx;
+
             const tm = new TransitionManager({
                 algorithmLoader: { speed: 0 },
                 canvas,
-                getDimensions: () => ({ h: 100, w: 100 }),
                 hudController: { displayAlgorithmName: vi.fn() },
             });
 

--- a/src/AlgorithmLoader.js
+++ b/src/AlgorithmLoader.js
@@ -27,6 +27,12 @@ export default class AlgorithmLoader {
      */
     static frequencyAnalyser = null;
 
+    static ctx = null;
+
+    static w = 0;
+
+    static h = 0;
+
     /**
      * Reference to GSAP animation library (global).
      * This expects GSAP to be loaded globally via <script src="./assets/js/gsap.min.js"></script> in index.html.
@@ -149,28 +155,20 @@ export default class AlgorithmLoader {
         return randomColor(minC, maxC, minA, maxA);
     }
 
+    t = 0;
+
+    animationFrameId = null;
+
+    speed = AlgorithmLoader.random(2, 5);
+
+    stagger = 0;
+
+    isRunning = true;
+
     /**
      * Initializes a new algorithm instance.
-     * @param {CanvasRenderingContext2D} ctx - The canvas 2D rendering context.
-     * @param {number} w - The width of the canvas.
-     * @param {number} h - The height of the canvas.
      */
-    constructor(ctx, w, h) {
-        this.ctx = ctx;
-        this.w = w;
-        this.h = h;
-
-        // Time related properties for animation control
-        this.t = 0;
-        this.animationFrameId = null;
-        this.speed = AlgorithmLoader.random(2, 5);
-
-        // Used for staggered animations
-        this.stagger = 0;
-
-        // Used for cleanup and error handling in the draw loop
-        this.isRunning = true;
-
+    constructor() {
         // Wrap the subclass draw() in an error boundary.
         // If the algorithm throws during animation, stop() is called and
         // an 'algorithm-error' event is dispatched so the app can recover.
@@ -183,7 +181,7 @@ export default class AlgorithmLoader {
                 originalDraw();
             } catch {
                 this.stop();
-                this.ctx.canvas.dispatchEvent(new CustomEvent('algorithm-error'));
+                AlgorithmLoader.ctx.canvas.dispatchEvent(new CustomEvent('algorithm-error'));
             }
         };
     }
@@ -194,10 +192,15 @@ export default class AlgorithmLoader {
      * Clears the entire canvas, resetting any transforms.
      */
     clearScreen() {
-        this.ctx.save();
-        this.ctx.resetTransform();
-        this.ctx.clearRect(0, 0, this.ctx.canvas.width, this.ctx.canvas.height);
-        this.ctx.restore();
+        AlgorithmLoader.ctx.save();
+        AlgorithmLoader.ctx.resetTransform();
+        AlgorithmLoader.ctx.clearRect(
+            0,
+            0,
+            AlgorithmLoader.ctx.canvas.width,
+            AlgorithmLoader.ctx.canvas.height,
+        );
+        AlgorithmLoader.ctx.restore();
     }
 
     /**
@@ -225,10 +228,15 @@ export default class AlgorithmLoader {
      * Fills the entire canvas with the current fill style, resetting any transforms.
      */
     fillScreen() {
-        this.ctx.save();
-        this.ctx.resetTransform();
-        this.ctx.fillRect(0, 0, this.ctx.canvas.width, this.ctx.canvas.height);
-        this.ctx.restore();
+        AlgorithmLoader.ctx.save();
+        AlgorithmLoader.ctx.resetTransform();
+        AlgorithmLoader.ctx.fillRect(
+            0,
+            0,
+            AlgorithmLoader.ctx.canvas.width,
+            AlgorithmLoader.ctx.canvas.height,
+        );
+        AlgorithmLoader.ctx.restore();
     }
 
     /**
@@ -244,9 +252,9 @@ export default class AlgorithmLoader {
      * @param {number} angle - The angle in degrees to rotate.
      */
     rotateCanvasDegrees(angle) {
-        this.ctx.translate(this.w / 2, this.h / 2);
-        this.ctx.rotate((angle * Math.PI) / 180);
-        this.ctx.translate(-this.w / 2, -this.h / 2);
+        AlgorithmLoader.ctx.translate(AlgorithmLoader.w / 2, AlgorithmLoader.h / 2);
+        AlgorithmLoader.ctx.rotate((angle * Math.PI) / 180);
+        AlgorithmLoader.ctx.translate(-AlgorithmLoader.w / 2, -AlgorithmLoader.h / 2);
     }
 
     /**
@@ -254,9 +262,9 @@ export default class AlgorithmLoader {
      * @param {number} angle - The angle in radians to rotate.
      */
     rotateCanvasRadians(angle) {
-        this.ctx.translate(this.w / 2, this.h / 2);
-        this.ctx.rotate(angle);
-        this.ctx.translate(-this.w / 2, -this.h / 2);
+        AlgorithmLoader.ctx.translate(AlgorithmLoader.w / 2, AlgorithmLoader.h / 2);
+        AlgorithmLoader.ctx.rotate(angle);
+        AlgorithmLoader.ctx.translate(-AlgorithmLoader.w / 2, -AlgorithmLoader.h / 2);
     }
 
     /**

--- a/src/Spiral.js
+++ b/src/Spiral.js
@@ -36,6 +36,11 @@ export default class Spiral {
         this.h = globalThis.innerHeight;
         this.applyDpr();
 
+        // Initialize static canvas properties for algorithms
+        AlgorithmLoader.ctx = this.ctx;
+        AlgorithmLoader.w = this.w;
+        AlgorithmLoader.h = this.h;
+
         // HUD SETUP
         this.hud = new HudController({
             algosDisplayElement: document.querySelector('#algos'),
@@ -44,12 +49,11 @@ export default class Spiral {
         });
 
         // ALGORITHM & TRANSITION MANAGEMENT
-        this.algorithmLoader = new AlgorithmLoader(this.ctx, this.w, this.h);
+        this.algorithmLoader = new AlgorithmLoader();
 
         this.transitionManager = new TransitionManager({
             algorithmLoader: this.algorithmLoader,
             canvas: this.canvas,
-            getDimensions: () => ({ h: this.h, w: this.w }),
             hudController: this.hud,
         });
 
@@ -86,6 +90,8 @@ export default class Spiral {
             const rect = this.canvas.getBoundingClientRect();
             this.w = rect.width;
             this.h = rect.height;
+            AlgorithmLoader.w = this.w;
+            AlgorithmLoader.h = this.h;
             this.applyDpr();
 
             // Also resize waveform canvas

--- a/src/TransitionManager.js
+++ b/src/TransitionManager.js
@@ -1,3 +1,4 @@
+import AlgorithmLoader from './AlgorithmLoader.js';
 import { algorithms } from './generated/algorithmRegistry.js';
 import { random, randomColor } from './utils/randomUtils.js';
 
@@ -28,14 +29,11 @@ export default class TransitionManager {
      * @param {HTMLCanvasElement} deps.canvas - The HTML canvas element
      * @param {import('./AlgorithmLoader.js').default} deps.algorithmLoader - Algorithm loader instance
      * @param {import('./HudController.js').default} deps.hudController - HUD controller instance
-     * @param {Function} deps.getDimensions  - Returns { w, h }
      */
-    constructor({ canvas, algorithmLoader, hudController, getDimensions }) {
+    constructor({ canvas, algorithmLoader, hudController }) {
         this.canvas = canvas;
-        this.ctx = canvas.getContext('2d');
         this.algorithmLoader = algorithmLoader;
         this.hudController = hudController;
-        this.getDimensions = getDimensions;
     }
 
     /** Change to a new algorithm, handling timing, errors, and dev mode. Idempotent if a transition is already in progress. */
@@ -87,8 +85,6 @@ export default class TransitionManager {
 
     /** Choose and instantiate a new algorithm, with retry logic for constructor errors. Respects dev mode settings. Idempotent if already transitioning. */
     chooseAlgos() {
-        const { w, h } = this.getDimensions();
-
         let AlgorithmClass = null;
         if (this.devModeActive) {
             // In dev mode, alternate between two specified algorithms (or random if null) on each call. This allows for quick testing of specific algorithms without changing code.
@@ -102,7 +98,7 @@ export default class TransitionManager {
 
         // Attempt to instantiate the chosen algorithm, with retry logic in case of constructor errors. This is important because some algorithms may throw errors due to edge cases or unexpected conditions. We want to ensure that a single failure doesn't break the entire app, and that we can recover gracefully by trying a different algorithm.
         try {
-            this.currentAlgorithm = new AlgorithmClass(this.ctx, w, h);
+            this.currentAlgorithm = new AlgorithmClass();
             this.hudController.displayAlgorithmName(this.currentAlgorithm.name);
             this.algoRetries = 0;
         } catch {
@@ -133,7 +129,8 @@ export default class TransitionManager {
      * resets and adds 7 previously missing ones.
      */
     resetCanvasContext() {
-        const { canvas, ctx } = this;
+        const { canvas } = this;
+        const { ctx } = AlgorithmLoader;
         const dpr = globalThis.devicePixelRatio || 1;
 
         // Reset transform fully (clears accumulated rotation)

--- a/src/algos/Abstractions.js
+++ b/src/algos/Abstractions.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Abstractions extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Abstractions';
 
@@ -23,27 +23,27 @@ export default class Abstractions extends AL {
     }
 
     initializeProperties() {
-        this.pointAx = AL.random(0, this.w);
-        this.pointAy = AL.random(0, this.h);
-        this.pointCpAx = AL.random(0, this.w);
-        this.pointCpAy = AL.random(0, this.h);
-        this.pointBx = AL.random(0, this.w);
-        this.pointBy = AL.random(0, this.h);
-        this.pointCpBx = AL.random(0, this.w);
-        this.pointCpBy = AL.random(0, this.h);
-        this.pointCx = AL.random(0, this.w);
-        this.pointCy = AL.random(0, this.h);
-        this.pointCpCx = AL.random(0, this.w);
-        this.pointCpCy = AL.random(0, this.h);
+        this.pointAx = AL.random(0, AL.w);
+        this.pointAy = AL.random(0, AL.h);
+        this.pointCpAx = AL.random(0, AL.w);
+        this.pointCpAy = AL.random(0, AL.h);
+        this.pointBx = AL.random(0, AL.w);
+        this.pointBy = AL.random(0, AL.h);
+        this.pointCpBx = AL.random(0, AL.w);
+        this.pointCpBy = AL.random(0, AL.h);
+        this.pointCx = AL.random(0, AL.w);
+        this.pointCy = AL.random(0, AL.h);
+        this.pointCpCx = AL.random(0, AL.w);
+        this.pointCpCy = AL.random(0, AL.h);
         this.rotate = AL.pickRandomElement(this.rotations);
     }
 
     setupConstantStyles() {
-        this.ctx.shadowBlur = 3;
+        AL.ctx.shadowBlur = 3;
     }
 
     setupDrawingStyles() {
-        this.ctx.shadowColor = this.ctx.strokeStyle = AL.randomColor(0, 255, 0.25, 0.45);
+        AL.ctx.shadowColor = AL.ctx.strokeStyle = AL.randomColor(0, 255, 0.25, 0.45);
     }
 
     draw() {
@@ -51,39 +51,24 @@ export default class Abstractions extends AL {
             this.stagger %= 4;
 
             if (this.stagger === 0) {
-                this.ctx.beginPath();
-                this.ctx.moveTo(this.pointCx, this.pointCy);
-                this.ctx.quadraticCurveTo(
-                    this.pointCpAx,
-                    this.pointCpAy,
-                    this.pointAx,
-                    this.pointAy,
-                );
-                this.ctx.stroke();
+                AL.ctx.beginPath();
+                AL.ctx.moveTo(this.pointCx, this.pointCy);
+                AL.ctx.quadraticCurveTo(this.pointCpAx, this.pointCpAy, this.pointAx, this.pointAy);
+                AL.ctx.stroke();
             }
 
             if (this.stagger === 1) {
-                this.ctx.beginPath();
-                this.ctx.moveTo(this.pointAx, this.pointAy);
-                this.ctx.quadraticCurveTo(
-                    this.pointCpBx,
-                    this.pointCpBy,
-                    this.pointBx,
-                    this.pointBy,
-                );
-                this.ctx.stroke();
+                AL.ctx.beginPath();
+                AL.ctx.moveTo(this.pointAx, this.pointAy);
+                AL.ctx.quadraticCurveTo(this.pointCpBx, this.pointCpBy, this.pointBx, this.pointBy);
+                AL.ctx.stroke();
             }
 
             if (this.stagger === 2) {
-                this.ctx.beginPath();
-                this.ctx.moveTo(this.pointBx, this.pointBy);
-                this.ctx.quadraticCurveTo(
-                    this.pointCpCx,
-                    this.pointCpCy,
-                    this.pointCx,
-                    this.pointCy,
-                );
-                this.ctx.stroke();
+                AL.ctx.beginPath();
+                AL.ctx.moveTo(this.pointBx, this.pointBy);
+                AL.ctx.quadraticCurveTo(this.pointCpCx, this.pointCpCy, this.pointCx, this.pointCy);
+                AL.ctx.stroke();
             }
         }
 

--- a/src/algos/AccelerationMandala.js
+++ b/src/algos/AccelerationMandala.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class AccelerationMandala extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Acceleration Mandala';
 
@@ -23,14 +23,14 @@ export default class AccelerationMandala extends AL {
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = AL.randomColor(12, 255, 0.33, 0.33);
-        this.ctx.font = `bold ${AL.random(125, 550)}px sans-serif`;
-        this.ctx.textAlign = 'center';
+        AL.ctx.strokeStyle = AL.randomColor(12, 255, 0.33, 0.33);
+        AL.ctx.font = `bold ${AL.random(125, 550)}px sans-serif`;
+        AL.ctx.textAlign = 'center';
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.strokeText(this.letter, this.w / 2, this.h / 2);
+            AL.ctx.strokeText(this.letter, AL.w / 2, AL.h / 2);
 
             this.rotateCanvasDegrees(this.rotate + 1);
         }
@@ -42,11 +42,11 @@ export default class AccelerationMandala extends AL {
         }
 
         if (this.t % (this.speed * 90) === 0) {
-            this.ctx.strokeStyle = AL.randomColor(12, 255, 0.33, 0.33);
+            AL.ctx.strokeStyle = AL.randomColor(12, 255, 0.33, 0.33);
         }
 
         if (this.t % (this.speed * 135) === 0) {
-            this.ctx.font = `bold ${AL.random(125, 550)}px sans-serif`;
+            AL.ctx.font = `bold ${AL.random(125, 550)}px sans-serif`;
         }
 
         if (this.t % (this.speed * 360) === 0) {

--- a/src/algos/AcidStars.js
+++ b/src/algos/AcidStars.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class AcidStars extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Acid Stars';
 
@@ -33,12 +33,12 @@ export default class AcidStars extends AL {
     }
 
     setupConstantStyles() {
-        this.ctx.shadowBlur = 15;
+        AL.ctx.shadowBlur = 15;
     }
 
     setupDrawingStyles() {
-        this.ctx.font = `${this.fontSize}px serif`;
-        this.ctx.shadowColor = this.ctx.fillStyle = AL.randomColor(0, 255, 1);
+        AL.ctx.font = `${this.fontSize}px serif`;
+        AL.ctx.shadowColor = AL.ctx.fillStyle = AL.randomColor(0, 255, 1);
     }
 
     draw() {
@@ -46,27 +46,27 @@ export default class AcidStars extends AL {
             this.stagger %= 3;
 
             if (this.stagger === 0) {
-                this.ctx.fillText(this.letter, this.w / 2 + this.side / 2, this.h / 2);
-                this.ctx.stroke();
+                AL.ctx.fillText(this.letter, AL.w / 2 + this.side / 2, AL.h / 2);
+                AL.ctx.stroke();
             }
 
             if (this.stagger === 1) {
-                this.ctx.fillText(this.letter, this.w / 2, this.h / 2 - this.side / 2);
+                AL.ctx.fillText(this.letter, AL.w / 2, AL.h / 2 - this.side / 2);
             }
 
             if (this.stagger === 2) {
-                this.ctx.translate(this.w / 2, this.h / 2);
-                this.ctx.rotate((-this.rotate * Math.PI) / 180);
-                this.ctx.fillText(this.letter, this.w / 2 - this.side / 2, this.h / 2);
-                this.ctx.stroke();
-                this.ctx.translate(-this.w / 2, -this.h / 2);
+                AL.ctx.translate(AL.w / 2, AL.h / 2);
+                AL.ctx.rotate((-this.rotate * Math.PI) / 180);
+                AL.ctx.fillText(this.letter, AL.w / 2 - this.side / 2, AL.h / 2);
+                AL.ctx.stroke();
+                AL.ctx.translate(-AL.w / 2, -AL.h / 2);
             }
 
             this.stagger += 1;
         }
 
         this.side += this.change;
-        if (this.side > Math.max(this.w, this.h) || this.side < 5) {
+        if (this.side > Math.max(AL.w, AL.h) || this.side < 5) {
             this.change = -this.change;
         }
 
@@ -75,7 +75,7 @@ export default class AcidStars extends AL {
         if (this.t % (this.speed * 240) === 0) {
             this.initializeProperties();
             this.setupDrawingStyles();
-            this.ctx.beginPath();
+            AL.ctx.beginPath();
         }
 
         if (this.t % (this.speed * 720) === 0) {

--- a/src/algos/AlienFlowers.js
+++ b/src/algos/AlienFlowers.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class AlienFlowers extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Alien Flowers';
 
@@ -16,22 +16,22 @@ export default class AlienFlowers extends AL {
     setupConstantStyles() {
         this.modes = ['hard-light', 'color-dodge', 'multiply', 'overlay', 'color-burn'];
 
-        this.ctx.lineJoin = 'bevel';
-        this.ctx.lineCap = 'round';
-        this.ctx.shadowBlur = 5;
+        AL.ctx.lineJoin = 'bevel';
+        AL.ctx.lineCap = 'round';
+        AL.ctx.shadowBlur = 5;
 
-        this.ctx.beginPath();
+        AL.ctx.beginPath();
     }
 
     setupBaseStyles() {
-        this.ctx.setLineDash([AL.random(1, 100), AL.random(5, 200)]);
-        this.ctx.globalCompositeOperation = 'source-over';
+        AL.ctx.setLineDash([AL.random(1, 100), AL.random(5, 200)]);
+        AL.ctx.globalCompositeOperation = 'source-over';
     }
 
     setupDrawingStyles() {
-        this.ctx.shadowColor = this.ctx.strokeStyle = AL.randomColor(5, 255, 0.1, 0.1);
+        AL.ctx.shadowColor = AL.ctx.strokeStyle = AL.randomColor(5, 255, 0.1, 0.1);
 
-        this.ctx.shadowOffsetX = this.ctx.shadowOffsetY = this.ctx.lineWidth = AL.random(3, 36);
+        AL.ctx.shadowOffsetX = AL.ctx.shadowOffsetY = AL.ctx.lineWidth = AL.random(3, 36);
     }
 
     draw() {
@@ -39,55 +39,55 @@ export default class AlienFlowers extends AL {
             this.stagger %= 4;
 
             if (this.stagger === 0) {
-                this.ctx.moveTo(this.w / 2, this.h / 2);
-                this.ctx.bezierCurveTo(
-                    AL.random(0, this.w / 2),
-                    AL.random(0, this.h / 2),
-                    AL.random(0, this.w / 4),
-                    AL.random(0, this.h / 4),
+                AL.ctx.moveTo(AL.w / 2, AL.h / 2);
+                AL.ctx.bezierCurveTo(
+                    AL.random(0, AL.w / 2),
+                    AL.random(0, AL.h / 2),
+                    AL.random(0, AL.w / 4),
+                    AL.random(0, AL.h / 4),
                     0,
                     0,
                 );
-                this.ctx.stroke();
+                AL.ctx.stroke();
             }
 
             if (this.stagger === 1) {
-                this.ctx.moveTo(this.w / 2, this.h / 2);
-                this.ctx.bezierCurveTo(
-                    AL.random(this.w / 2, this.w),
-                    AL.random(0, this.h / 2),
-                    AL.random(this.w * 0.75, this.w),
-                    AL.random(0, this.h * 0.25),
-                    this.w,
+                AL.ctx.moveTo(AL.w / 2, AL.h / 2);
+                AL.ctx.bezierCurveTo(
+                    AL.random(AL.w / 2, AL.w),
+                    AL.random(0, AL.h / 2),
+                    AL.random(AL.w * 0.75, AL.w),
+                    AL.random(0, AL.h * 0.25),
+                    AL.w,
                     0,
                 );
-                this.ctx.stroke();
+                AL.ctx.stroke();
             }
 
             if (this.stagger === 2) {
-                this.ctx.moveTo(this.w / 2, this.h / 2);
-                this.ctx.bezierCurveTo(
-                    AL.random(this.w / 2, this.w),
-                    AL.random(this.h / 2, this.h),
-                    AL.random(this.w * 0.75, this.w),
-                    AL.random(this.h * 0.75, this.h),
-                    this.w,
-                    this.h,
+                AL.ctx.moveTo(AL.w / 2, AL.h / 2);
+                AL.ctx.bezierCurveTo(
+                    AL.random(AL.w / 2, AL.w),
+                    AL.random(AL.h / 2, AL.h),
+                    AL.random(AL.w * 0.75, AL.w),
+                    AL.random(AL.h * 0.75, AL.h),
+                    AL.w,
+                    AL.h,
                 );
-                this.ctx.stroke();
+                AL.ctx.stroke();
             }
 
             if (this.stagger === 3) {
-                this.ctx.moveTo(this.w / 2, this.h / 2);
-                this.ctx.bezierCurveTo(
-                    AL.random(0, this.w / 2),
-                    AL.random(this.h / 2, this.h),
-                    AL.random(0, this.w * 0.25),
-                    AL.random(this.h * 0.75, this.h),
+                AL.ctx.moveTo(AL.w / 2, AL.h / 2);
+                AL.ctx.bezierCurveTo(
+                    AL.random(0, AL.w / 2),
+                    AL.random(AL.h / 2, AL.h),
+                    AL.random(0, AL.w * 0.25),
+                    AL.random(AL.h * 0.75, AL.h),
                     0,
-                    this.h,
+                    AL.h,
                 );
-                this.ctx.stroke();
+                AL.ctx.stroke();
             }
 
             this.stagger += 1;
@@ -100,18 +100,18 @@ export default class AlienFlowers extends AL {
         }
 
         if (this.t % (this.speed * 32) === 0) {
-            this.ctx.globalCompositeOperation = AL.pickRandomElement(this.modes);
+            AL.ctx.globalCompositeOperation = AL.pickRandomElement(this.modes);
 
-            this.ctx.beginPath();
+            AL.ctx.beginPath();
         }
 
         if (this.t % (this.speed * 64) === 0) {
             this.setupDrawingStyles();
-            this.ctx.beginPath();
+            AL.ctx.beginPath();
         }
 
         if (this.t % (this.speed * 256) === 0) {
-            this.ctx.setLineDash([AL.random(1, 100), AL.random(5, 200)]);
+            AL.ctx.setLineDash([AL.random(1, 100), AL.random(5, 200)]);
         }
 
         this.requestFrame();

--- a/src/algos/AlphabetSoup.js
+++ b/src/algos/AlphabetSoup.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class AlphabetSoup extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Alphabet Soup';
 
@@ -34,18 +34,18 @@ export default class AlphabetSoup extends AL {
 
     setupDrawingStyles() {
         this.fontChange = AL.random(35, 180);
-        this.ctx.font = `${this.fontChange}px sans-serif`;
-        this.ctx.fillStyle = AL.randomColor(0, 255, 0.45, 0.7);
+        AL.ctx.font = `${this.fontChange}px sans-serif`;
+        AL.ctx.fillStyle = AL.randomColor(0, 255, 0.45, 0.7);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
             this.rotateCanvasDegrees(this.rotate);
 
-            this.ctx.fillText(
+            AL.ctx.fillText(
                 `${this.letter1} ${this.letter2} ${this.letter3} ${this.letter4}`,
-                this.w / 2,
-                this.h / 2,
+                AL.w / 2,
+                AL.h / 2,
             );
         }
 

--- a/src/algos/AngelHair.js
+++ b/src/algos/AngelHair.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class AngelHair extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Angel Hair';
 
@@ -18,20 +18,20 @@ export default class AngelHair extends AL {
     }
 
     initializeProperties() {
-        this.x1 = AL.random(0, this.w);
-        this.y1 = AL.random(0, this.h);
-        this.x2 = AL.random(0, this.w);
-        this.y2 = AL.random(0, this.h);
+        this.x1 = AL.random(0, AL.w);
+        this.y1 = AL.random(0, AL.h);
+        this.x2 = AL.random(0, AL.w);
+        this.y2 = AL.random(0, AL.h);
         this.rotate = AL.random(2, 359);
         this.radius1 = AL.random(20, 300);
         this.radius2 = AL.random(20, 300);
     }
 
     setupDrawingStyles() {
-        this.ctx.lineWidth = 0.3;
-        this.ctx.setLineDash([1, 4]);
-        this.ctx.globalCompositeOperation = 'hard-light';
-        this.ctx.strokeStyle = AL.randomColor(120, 255, 0.66, 0.95);
+        AL.ctx.lineWidth = 0.3;
+        AL.ctx.setLineDash([1, 4]);
+        AL.ctx.globalCompositeOperation = 'hard-light';
+        AL.ctx.strokeStyle = AL.randomColor(120, 255, 0.66, 0.95);
     }
 
     draw() {
@@ -39,17 +39,17 @@ export default class AngelHair extends AL {
             this.stagger %= 4;
 
             if (this.stagger === 0) {
-                this.ctx.moveTo(this.y2, this.x1);
+                AL.ctx.moveTo(this.y2, this.x1);
             }
 
             if (this.stagger === 1) {
-                this.ctx.arcTo(this.w / 2, this.h, this.x1, this.y1, this.radius1);
-                this.ctx.stroke();
+                AL.ctx.arcTo(AL.w / 2, AL.h, this.x1, this.y1, this.radius1);
+                AL.ctx.stroke();
             }
 
             if (this.stagger === 2) {
-                this.ctx.arcTo(this.w, this.h / 2, this.x2, this.y2, this.radius2);
-                this.ctx.stroke();
+                AL.ctx.arcTo(AL.w, AL.h / 2, this.x2, this.y2, this.radius2);
+                AL.ctx.stroke();
             }
 
             if (this.stagger === 3) {
@@ -64,10 +64,10 @@ export default class AngelHair extends AL {
         if (this.t % (this.speed * 360) === 0) {
             this.initializeProperties();
 
-            this.ctx.strokeStyle =
+            AL.ctx.strokeStyle =
                 Math.random() < 0.075 ? 'white' : AL.randomColor(120, 255, 0.66, 0.95);
 
-            this.ctx.beginPath();
+            AL.ctx.beginPath();
         }
 
         this.requestFrame();

--- a/src/algos/Aperture.js
+++ b/src/algos/Aperture.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Aperture extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Aperture';
 
@@ -14,30 +14,30 @@ export default class Aperture extends AL {
     }
 
     initializeBaseProperties() {
-        this.white = true;
+        AL.white = true;
     }
 
     initializeProperties() {
-        this.height = AL.random(100, this.h - 100);
-        this.width = AL.random(100, this.w - 100);
-        this.y = AL.random(100, this.h - 100);
+        this.height = AL.random(100, AL.h - 100);
+        this.width = AL.random(100, AL.w - 100);
+        this.y = AL.random(100, AL.h - 100);
         this.round = AL.random(5, 100);
         this.rotate = AL.random(1, 70);
         this.incX = Math.random();
         this.incH = Math.random();
-        this.x = this.w / 2;
+        this.x = AL.w / 2;
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = 'white';
-        this.ctx.fillStyle = 'black';
-        this.ctx.globalAlpha = 0.75;
-        this.ctx.lineWidth = 4;
+        AL.ctx.strokeStyle = 'white';
+        AL.ctx.fillStyle = 'black';
+        AL.ctx.globalAlpha = 0.75;
+        AL.ctx.lineWidth = 4;
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.roundRectExtra(
+            AL.ctx.roundRectExtra(
                 this.x,
                 this.y,
                 this.width,
@@ -60,19 +60,19 @@ export default class Aperture extends AL {
         this.rotateCanvasRadians(this.rotate);
 
         if (this.t % (this.speed * 300) === 0) {
-            if (this.white) {
-                this.ctx.strokeStyle = 'black';
-                this.ctx.fillStyle = 'white';
+            if (AL.white) {
+                AL.ctx.strokeStyle = 'black';
+                AL.ctx.fillStyle = 'white';
             } else {
-                this.ctx.strokeStyle = 'white';
-                this.ctx.fillStyle = 'black';
+                AL.ctx.strokeStyle = 'white';
+                AL.ctx.fillStyle = 'black';
             }
 
-            this.white = !this.white;
+            AL.white = !AL.white;
 
             this.initializeProperties();
 
-            this.ctx.beginPath();
+            AL.ctx.beginPath();
         }
 
         this.requestFrame();

--- a/src/algos/Atom.js
+++ b/src/algos/Atom.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Atom extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Atom';
 
@@ -20,22 +20,22 @@ export default class Atom extends AL {
     }
 
     setupConstantStyles() {
-        this.ctx.shadowColor = 'black';
-        this.ctx.shadowBlur = 2;
-        this.ctx.lineWidth = 5;
+        AL.ctx.shadowColor = 'black';
+        AL.ctx.shadowBlur = 2;
+        AL.ctx.lineWidth = 5;
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = AL.randomColor(65, 255, 0.5, 1);
+        AL.ctx.strokeStyle = AL.randomColor(65, 255, 0.5, 1);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.lineTo(this.w / 2 + this.change, this.h / 2);
-            this.ctx.stroke();
+            AL.ctx.lineTo(AL.w / 2 + this.change, AL.h / 2);
+            AL.ctx.stroke();
 
             this.change += this.rate;
-            if (Math.abs(this.change) > Math.max(this.w / 2, this.h / 2)) {
+            if (Math.abs(this.change) > Math.max(AL.w / 2, AL.h / 2)) {
                 this.rate = -this.rate;
             }
 
@@ -47,7 +47,7 @@ export default class Atom extends AL {
         if (this.t % (this.speed * 450) === 0) {
             this.initializeProperties();
             this.setupDrawingStyles();
-            this.ctx.beginPath();
+            AL.ctx.beginPath();
         }
 
         this.requestFrame();

--- a/src/algos/Autumn.js
+++ b/src/algos/Autumn.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Autumn extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Autumn';
 
@@ -24,22 +24,22 @@ export default class Autumn extends AL {
     }
 
     setupDrawingStyles() {
-        this.ctx.fillStyle = AL.randomColor(0, 255, 0.1, 0.6);
+        AL.ctx.fillStyle = AL.randomColor(0, 255, 0.1, 0.6);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.beginPath();
-            this.ctx.arc(this.x, this.y, this.size, 0, Math.PI);
-            this.ctx.fill();
+            AL.ctx.beginPath();
+            AL.ctx.arc(this.x, this.y, this.size, 0, Math.PI);
+            AL.ctx.fill();
 
             this.x += this.size;
-            if (this.x > this.w) {
+            if (this.x > AL.w) {
                 this.x = 0;
                 this.y += this.size;
                 this.size = AL.random(15, 110);
             }
-            if (this.y > this.h) {
+            if (this.y > AL.h) {
                 this.initializeProperties();
                 this.setupDrawingStyles();
             }

--- a/src/algos/BigBangs.js
+++ b/src/algos/BigBangs.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class BigBangs extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Big Bangs';
 
@@ -20,31 +20,31 @@ export default class BigBangs extends AL {
     }
 
     setupConstantStyles() {
-        this.ctx.globalCompositeOperation = 'hard-light';
+        AL.ctx.globalCompositeOperation = 'hard-light';
     }
 
     setupDrawingStyles() {
-        this.ctx.fillStyle = AL.randomColor(0, 255, 0.02, 0.05);
-        this.ctx.strokeStyle = AL.randomColor(0, 255, 0.5, 1);
+        AL.ctx.fillStyle = AL.randomColor(0, 255, 0.02, 0.05);
+        AL.ctx.strokeStyle = AL.randomColor(0, 255, 0.5, 1);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.arc(this.w / 2, this.h / 2, this.radius, 0, 2 * Math.PI);
-            this.ctx.fill();
-            this.ctx.stroke();
+            AL.ctx.arc(AL.w / 2, AL.h / 2, this.radius, 0, 2 * Math.PI);
+            AL.ctx.fill();
+            AL.ctx.stroke();
 
             this.radius += this.increment;
         }
 
         this.rotateCanvasDegrees(this.angle);
 
-        if (this.radius > Math.max(this.w, this.h)) {
+        if (this.radius > Math.max(AL.w, AL.h)) {
             this.initializeProperties();
             this.setupDrawingStyles();
 
             this.fillScreen();
-            this.ctx.beginPath();
+            AL.ctx.beginPath();
         }
 
         this.t += 1;

--- a/src/algos/BlacknWhite.js
+++ b/src/algos/BlacknWhite.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class BlacknWhite extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Black & White';
 
@@ -14,12 +14,12 @@ export default class BlacknWhite extends AL {
 
     initializeProperties() {
         this.height = this.length / AL.random(1, 5);
-        this.length = AL.random(50, Math.min(this.w, this.h) / 1.5);
+        this.length = AL.random(50, Math.min(AL.w, AL.h) / 1.5);
     }
 
     setupDrawingStyles() {
-        this.ctx.lineWidth = 4;
-        this.ctx.strokeStyle = 'white';
+        AL.ctx.lineWidth = 4;
+        AL.ctx.strokeStyle = 'white';
         this.modes = ['source-over', 'difference', 'destination-out'];
     }
 
@@ -28,16 +28,16 @@ export default class BlacknWhite extends AL {
             this.stagger %= 4;
 
             if (this.stagger === 0) {
-                this.ctx.beginPath();
-                this.ctx.moveTo(this.w / 2, this.h / 2);
-                this.ctx.strokeRect(
-                    this.w / 2 - this.length / 2,
-                    this.h / 2 - this.height / 2,
+                AL.ctx.beginPath();
+                AL.ctx.moveTo(AL.w / 2, AL.h / 2);
+                AL.ctx.strokeRect(
+                    AL.w / 2 - this.length / 2,
+                    AL.h / 2 - this.height / 2,
                     this.length,
                     this.height,
                 );
 
-                this.length = AL.random(20, Math.max(this.w, this.h));
+                this.length = AL.random(20, Math.max(AL.w, AL.h));
                 this.height = this.length / AL.random(1, 5);
             }
 
@@ -46,13 +46,13 @@ export default class BlacknWhite extends AL {
             }
 
             if (this.stagger === 2) {
-                this.ctx.arcTo(this.height, this.length, 0, this.h / 2, this.w / 2);
-                this.ctx.stroke();
+                AL.ctx.arcTo(this.height, this.length, 0, AL.h / 2, AL.w / 2);
+                AL.ctx.stroke();
             }
 
             if (this.stagger === 3) {
-                this.ctx.arcTo(this.w / 2, this.h / 2, AL.random(1, 10), this.height, this.length);
-                this.ctx.stroke();
+                AL.ctx.arcTo(AL.w / 2, AL.h / 2, AL.random(1, 10), this.height, this.length);
+                AL.ctx.stroke();
             }
 
             this.stagger += 1;
@@ -61,7 +61,7 @@ export default class BlacknWhite extends AL {
         this.t += 1;
 
         if (this.t % (this.speed * 100) === 0) {
-            this.ctx.globalCompositeOperation = AL.pickRandomElement(this.modes);
+            AL.ctx.globalCompositeOperation = AL.pickRandomElement(this.modes);
         }
 
         this.requestFrame();

--- a/src/algos/Blends.js
+++ b/src/algos/Blends.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Blends extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Blends';
 
@@ -14,10 +14,10 @@ export default class Blends extends AL {
     }
 
     initializeProperties() {
-        this.x = AL.random(0, this.w);
-        this.y = AL.random(0, this.h);
-        this.x2 = AL.random(0, this.w);
-        this.y2 = AL.random(0, this.h);
+        this.x = AL.random(0, AL.w);
+        this.y = AL.random(0, AL.h);
+        this.x2 = AL.random(0, AL.w);
+        this.y2 = AL.random(0, AL.h);
         this.length = AL.random(30, 250);
         this.rotation = AL.random(2, 140);
         this.currentShape = AL.random(0, 3);
@@ -26,29 +26,29 @@ export default class Blends extends AL {
     }
 
     setupConstantStyles() {
-        this.ctx.lineWidth = 3;
+        AL.ctx.lineWidth = 3;
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = AL.randomColor();
+        AL.ctx.strokeStyle = AL.randomColor();
     }
 
     draw() {
         if (this.t % this.speed === 0) {
             if (this.currentShape === 0) {
-                this.ctx.fillStyle = this.color2;
-                this.ctx.fillRect(this.x, this.y, this.length, this.length);
+                AL.ctx.fillStyle = this.color2;
+                AL.ctx.fillRect(this.x, this.y, this.length, this.length);
             } else if (this.currentShape === 1) {
-                this.ctx.fillStyle = this.color1;
-                this.ctx.beginPath();
-                this.ctx.arc(this.x2, this.y2, this.length, 0, 2 * Math.PI);
-                this.ctx.fill();
+                AL.ctx.fillStyle = this.color1;
+                AL.ctx.beginPath();
+                AL.ctx.arc(this.x2, this.y2, this.length, 0, 2 * Math.PI);
+                AL.ctx.fill();
             } else {
-                this.ctx.strokeStyle = this.color2;
-                this.ctx.beginPath();
-                this.ctx.moveTo(this.x, this.y);
-                this.ctx.lineTo(this.x2, this.y2);
-                this.ctx.stroke();
+                AL.ctx.strokeStyle = this.color2;
+                AL.ctx.beginPath();
+                AL.ctx.moveTo(this.x, this.y);
+                AL.ctx.lineTo(this.x2, this.y2);
+                AL.ctx.stroke();
             }
 
             this.x += 1;
@@ -67,7 +67,7 @@ export default class Blends extends AL {
         if (this.t % (this.speed * 270) === 0) {
             this.initializeProperties();
             this.setupDrawingStyles();
-            this.ctx.beginPath();
+            AL.ctx.beginPath();
         }
 
         this.requestFrame();

--- a/src/algos/Blur.js
+++ b/src/algos/Blur.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Blur extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Blur';
 
@@ -23,27 +23,27 @@ export default class Blur extends AL {
         this.factor = AL.random(3, 20);
         this.rotate = AL.random(1, 71);
         this.circles = AL.random(8, 25);
-        this.radius = AL.random(25, Math.max(this.w, this.h) / 2);
+        this.radius = AL.random(25, Math.max(AL.w, AL.h) / 2);
     }
 
     setupConstantStyles() {
-        this.ctx.lineWidth = 0.25;
+        AL.ctx.lineWidth = 0.25;
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = AL.randomColor(0, 255, 0.5, 1);
+        AL.ctx.strokeStyle = AL.randomColor(0, 255, 0.5, 1);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
             for (let i = 0; i < this.circles * 2; i++) {
                 this.angle = (i * Math.PI * 2) / this.circles;
-                const x = this.w / 2 + Math.cos(this.angle) * this.radius;
-                const y = this.h / 2 + Math.sin(this.angle) * this.radius;
+                const x = AL.w / 2 + Math.cos(this.angle) * this.radius;
+                const y = AL.h / 2 + Math.sin(this.angle) * this.radius;
 
-                this.ctx.beginPath();
-                this.ctx.arc(x, y, this.size + i * this.factor, 0, 2 * Math.PI);
-                this.ctx.stroke();
+                AL.ctx.beginPath();
+                AL.ctx.arc(x, y, this.size + i * this.factor, 0, 2 * Math.PI);
+                AL.ctx.stroke();
             }
         }
 
@@ -57,7 +57,7 @@ export default class Blur extends AL {
         }
 
         if (this.t % (this.speed * 630) === 0) {
-            this.ctx.strokeStyle = 'black';
+            AL.ctx.strokeStyle = 'black';
         }
 
         this.requestFrame();

--- a/src/algos/Boxes.js
+++ b/src/algos/Boxes.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Boxes extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Boxes';
 
@@ -22,28 +22,23 @@ export default class Boxes extends AL {
     initializeProperties() {
         this.rows = AL.random(3, 17);
         this.cols = AL.random(3, 17);
-        this.width = this.w / this.cols;
-        this.height = this.h / this.rows;
+        this.width = AL.w / this.cols;
+        this.height = AL.h / this.rows;
     }
 
     setupConstantStyles() {
-        this.ctx.strokeStyle = 'black';
+        AL.ctx.strokeStyle = 'black';
     }
 
     setupDrawingStyles() {
-        this.ctx.fillStyle = AL.randomColor(0, 255, 0.075, 0.075);
+        AL.ctx.fillStyle = AL.randomColor(0, 255, 0.075, 0.075);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
             for (let i = 0; i <= this.rows; i++) {
-                this.ctx.fillRect(i * this.width, i * this.height, this.width / 2, this.height / 2);
-                this.ctx.strokeRect(
-                    i * this.width,
-                    i * this.height,
-                    this.width / 2,
-                    this.height / 2,
-                );
+                AL.ctx.fillRect(i * this.width, i * this.height, this.width / 2, this.height / 2);
+                AL.ctx.strokeRect(i * this.width, i * this.height, this.width / 2, this.height / 2);
             }
         }
 

--- a/src/algos/CamouflagePostits.js
+++ b/src/algos/CamouflagePostits.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class CamouflagePostits extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Camouflage Post-its';
 
@@ -29,20 +29,20 @@ export default class CamouflagePostits extends AL {
     }
 
     initializeProperties() {
-        this.x = AL.random(0, this.w);
-        this.y = AL.random(0, this.h);
+        this.x = AL.random(0, AL.w);
+        this.y = AL.random(0, AL.h);
         this.randCol = AL.random(0, 255);
-        this.length = AL.random(50, Math.min(this.w, this.h) / 1.5);
+        this.length = AL.random(50, Math.min(AL.w, AL.h) / 1.5);
     }
 
     setupConstantStyles() {
-        this.ctx.lineWidth = 2;
-        this.ctx.strokeStyle = 'white';
-        this.ctx.moveTo(this.w / 2, this.h / 2);
+        AL.ctx.lineWidth = 2;
+        AL.ctx.strokeStyle = 'white';
+        AL.ctx.moveTo(AL.w / 2, AL.h / 2);
     }
 
     setupDrawingStyles() {
-        this.ctx.fillStyle = `rgb(
+        AL.ctx.fillStyle = `rgb(
         ${this.randCol + AL.random(-8, 8)},
         ${this.randCol + AL.random(-8, 8)},
         ${this.randCol + AL.random(-8, 8)}
@@ -51,10 +51,10 @@ export default class CamouflagePostits extends AL {
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.fillRect(this.x, this.y, this.length, this.length);
+            AL.ctx.fillRect(this.x, this.y, this.length, this.length);
 
-            this.x = AL.random(0, this.w);
-            this.y = AL.random(0, this.h);
+            this.x = AL.random(0, AL.w);
+            this.y = AL.random(0, AL.h);
 
             this.rotateCanvasRadians(AL.random(0, 360));
         }
@@ -65,15 +65,15 @@ export default class CamouflagePostits extends AL {
             this.length = AL.random(5, 125);
             this.randCol = AL.random(0, 255);
 
-            this.ctx.fillRect(
-                this.w / 2 - this.length * 1.5,
-                this.h / 2 - this.length * 1.5,
+            AL.ctx.fillRect(
+                AL.w / 2 - this.length * 1.5,
+                AL.h / 2 - this.length * 1.5,
                 3 * this.length,
                 3 * this.length,
             );
-            this.ctx.strokeRect(
-                this.w / 2 - this.length * 1.5,
-                this.h / 2 - this.length * 1.5,
+            AL.ctx.strokeRect(
+                AL.w / 2 - this.length * 1.5,
+                AL.h / 2 - this.length * 1.5,
                 3 * this.length,
                 3 * this.length,
             );
@@ -82,7 +82,7 @@ export default class CamouflagePostits extends AL {
         }
 
         if (this.t % (this.speed * 100) === 0) {
-            this.ctx.globalCompositeOperation = AL.pickRandomElement(this.modes);
+            AL.ctx.globalCompositeOperation = AL.pickRandomElement(this.modes);
         }
 
         this.requestFrame();

--- a/src/algos/ChalkGalaxy.js
+++ b/src/algos/ChalkGalaxy.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class ChalkGalaxy extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Chalk Galaxy';
 
@@ -23,15 +23,15 @@ export default class ChalkGalaxy extends AL {
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = AL.randomColor(150, 255, 0.25, 0.25);
-        this.ctx.font = `${AL.random(100, 700)}px bold`;
-        this.ctx.fillStyle = 'rgba(0, 0, 0, 0.45)';
-        this.ctx.fillRect(0, 0, this.w, this.h);
+        AL.ctx.strokeStyle = AL.randomColor(150, 255, 0.25, 0.25);
+        AL.ctx.font = `${AL.random(100, 700)}px bold`;
+        AL.ctx.fillStyle = 'rgba(0, 0, 0, 0.45)';
+        AL.ctx.fillRect(0, 0, AL.w, AL.h);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.strokeText(this.letter, this.w / 2, this.h / 2);
+            AL.ctx.strokeText(this.letter, AL.w / 2, AL.h / 2);
 
             this.rotateCanvasRadians(this.rotate);
         }
@@ -39,12 +39,12 @@ export default class ChalkGalaxy extends AL {
         this.t += 1;
 
         if (this.t % (this.speed * 100) === 0) {
-            this.ctx.strokeStyle = AL.randomColor(170, 255, 0.2, 0.2);
-            this.ctx.font = `${AL.random(100, 600)}px bold`;
+            AL.ctx.strokeStyle = AL.randomColor(170, 255, 0.2, 0.2);
+            AL.ctx.font = `${AL.random(100, 600)}px bold`;
         }
 
         if (this.t % (this.speed * 500) === 0) {
-            this.ctx.strokeStyle = AL.randomColor(0, 115, 0.2, 0.2);
+            AL.ctx.strokeStyle = AL.randomColor(0, 115, 0.2, 0.2);
             this.rotate = AL.random(1, 179);
         }
 

--- a/src/algos/Chillout.js
+++ b/src/algos/Chillout.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Chillout extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Chillout';
 
@@ -14,29 +14,29 @@ export default class Chillout extends AL {
     }
 
     initializeProperties() {
-        this.x1 = AL.random(0, this.w);
-        this.y1 = AL.random(0, this.h);
-        this.x2 = AL.random(0, this.w);
-        this.y2 = AL.random(0, this.h);
-        this.x3 = AL.random(0, this.w);
-        this.y3 = AL.random(0, this.h);
+        this.x1 = AL.random(0, AL.w);
+        this.y1 = AL.random(0, AL.h);
+        this.x2 = AL.random(0, AL.w);
+        this.y2 = AL.random(0, AL.h);
+        this.x3 = AL.random(0, AL.w);
+        this.y3 = AL.random(0, AL.h);
         this.rotate = AL.random(1, 10);
     }
 
     setupConstantStyles() {
-        this.ctx.filter = 'saturate(17.5%)';
+        AL.ctx.filter = 'saturate(17.5%)';
     }
 
     setupDrawingStyles() {
-        this.ctx.lineWidth = AL.random(1, 5);
-        this.ctx.strokeStyle = AL.randomColor(0, 255, 0.4, 1);
+        AL.ctx.lineWidth = AL.random(1, 5);
+        AL.ctx.strokeStyle = AL.randomColor(0, 255, 0.4, 1);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.moveTo(this.x3, this.y3);
-            this.ctx.quadraticCurveTo(this.x2, this.y2, this.x1, this.y1);
-            this.ctx.stroke();
+            AL.ctx.moveTo(this.x3, this.y3);
+            AL.ctx.quadraticCurveTo(this.x2, this.y2, this.x1, this.y1);
+            AL.ctx.stroke();
 
             this.rotateCanvasRadians(this.rotate);
         }
@@ -47,7 +47,7 @@ export default class Chillout extends AL {
             this.initializeProperties();
             this.setupDrawingStyles();
 
-            this.ctx.beginPath();
+            AL.ctx.beginPath();
         }
 
         this.requestFrame();

--- a/src/algos/Clock.js
+++ b/src/algos/Clock.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Clock extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Clock';
 
@@ -40,47 +40,47 @@ export default class Clock extends AL {
     }
 
     setupDrawingStyles() {
-        this.ctx.shadowColor = this.ctx.strokeStyle = this.color;
-        this.ctx.font = `${AL.random(60, 600)}px sans-serif`;
-        this.ctx.globalCompositeOperation = 'source-over';
-        this.ctx.textAlign = 'center';
-        this.ctx.shadowBlur = 8;
-        this.ctx.lineWidth = 3;
+        AL.ctx.shadowColor = AL.ctx.strokeStyle = this.color;
+        AL.ctx.font = `${AL.random(60, 600)}px sans-serif`;
+        AL.ctx.globalCompositeOperation = 'source-over';
+        AL.ctx.textAlign = 'center';
+        AL.ctx.shadowBlur = 8;
+        AL.ctx.lineWidth = 3;
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.translate(this.w / 2, this.h / 2);
-            this.ctx.strokeText(`  ${this.letter}`, 0, 0);
-            this.ctx.rotate(this.rotate);
-            this.ctx.translate(-this.w / 2, -this.h / 2);
-            this.ctx.beginPath();
+            AL.ctx.translate(AL.w / 2, AL.h / 2);
+            AL.ctx.strokeText(`  ${this.letter}`, 0, 0);
+            AL.ctx.rotate(this.rotate);
+            AL.ctx.translate(-AL.w / 2, -AL.h / 2);
+            AL.ctx.beginPath();
         }
 
         this.t += 1;
 
         if (this.t % (this.speed * 40) === 0) {
-            this.ctx.font = `${AL.random(60, 600)}px sans-serif`;
+            AL.ctx.font = `${AL.random(60, 600)}px sans-serif`;
 
             const col = Math.random();
             if (col < 0.15) {
-                this.ctx.lineWidth = 2;
-                this.ctx.shadowBlur = 12;
+                AL.ctx.lineWidth = 2;
+                AL.ctx.shadowBlur = 12;
                 this.color = 'rgba(255, 255, 255, 0.5)';
             } else if (col < 0.3) {
-                this.ctx.lineWidth = 5;
+                AL.ctx.lineWidth = 5;
                 this.color = 'rgba(0, 0, 0, 0.5)';
             } else {
-                this.ctx.shadowBlur = 8;
-                this.ctx.lineWidth = 3;
+                AL.ctx.shadowBlur = 8;
+                AL.ctx.lineWidth = 3;
                 this.color = AL.randomColor(0, 255, 0.66, 0.66);
             }
 
-            this.ctx.shadowColor = this.ctx.strokeStyle = this.color;
+            AL.ctx.shadowColor = AL.ctx.strokeStyle = this.color;
         }
 
         if (this.t % (this.speed * 120) === 0) {
-            this.ctx.globalCompositeOperation = AL.pickRandomElement(this.modes);
+            AL.ctx.globalCompositeOperation = AL.pickRandomElement(this.modes);
         }
 
         if (this.t % (this.speed * 200) === 0) {

--- a/src/algos/Coils.js
+++ b/src/algos/Coils.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Coils extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Coils';
 
@@ -39,23 +39,23 @@ export default class Coils extends AL {
         this.obj2 = {
             color: AL.randomColor(60, 255, 0.6, 1),
             radius: AL.random(30, 130),
-            x: this.w / 2,
-            y: this.h / 2,
+            x: AL.w / 2,
+            y: AL.h / 2,
         };
     }
 
     setupDrawingStyles() {
-        this.ctx.shadowBlur = 15;
-        this.ctx.strokeStyle = this.ctx.shadowColor = this.obj1.color;
+        AL.ctx.shadowBlur = 15;
+        AL.ctx.strokeStyle = AL.ctx.shadowColor = this.obj1.color;
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.beginPath();
-            this.ctx.arc(this.obj1.x, this.obj1.y, this.obj1.radius, 0, 2 * Math.PI);
-            this.ctx.fill();
-            this.ctx.stroke();
-            this.ctx.closePath();
+            AL.ctx.beginPath();
+            AL.ctx.arc(this.obj1.x, this.obj1.y, this.obj1.radius, 0, 2 * Math.PI);
+            AL.ctx.fill();
+            AL.ctx.stroke();
+            AL.ctx.closePath();
         }
 
         this.rotateCanvasRadians(this.rot);
@@ -111,7 +111,7 @@ export default class Coils extends AL {
                     duration: this.dur4,
                     ease: 'power1',
                     onUpdate: () => {
-                        this.ctx.strokeStyle = this.ctx.shadowColor = this.obj1.color;
+                        AL.ctx.strokeStyle = AL.ctx.shadowColor = this.obj1.color;
                     },
                 },
                 '<',

--- a/src/algos/Comets.js
+++ b/src/algos/Comets.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Comets extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Comets';
 
@@ -24,10 +24,10 @@ export default class Comets extends AL {
     }
 
     setupDrawingStyles() {
-        this.ctx.beginPath();
-        this.ctx.lineWidth = AL.random(3, 12);
-        this.ctx.shadowBlur = this.ctx.lineWidth;
-        this.ctx.shadowColor = this.ctx.strokeStyle = AL.randomColor();
+        AL.ctx.beginPath();
+        AL.ctx.lineWidth = AL.random(3, 12);
+        AL.ctx.shadowBlur = AL.ctx.lineWidth;
+        AL.ctx.shadowColor = AL.ctx.strokeStyle = AL.randomColor();
     }
 
     draw() {
@@ -35,11 +35,11 @@ export default class Comets extends AL {
             this.stagger %= 4;
 
             if (this.stagger === 0) {
-                this.ctx.lineTo(this.w / 2 + this.change, this.h / 2);
+                AL.ctx.lineTo(AL.w / 2 + this.change, AL.h / 2);
             }
 
             if (this.stagger === 1) {
-                this.ctx.stroke();
+                AL.ctx.stroke();
             }
 
             if (this.stagger === 2) {

--- a/src/algos/Concentric.js
+++ b/src/algos/Concentric.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Concentric extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Concentric';
 
@@ -31,26 +31,26 @@ export default class Concentric extends AL {
         this.angle = AL.pickRandomElement(this.angles);
 
         this.size = AL.random(25, 160);
-        this.y = AL.random(0, this.h);
-        this.x = AL.random(0, this.w);
+        this.y = AL.random(0, AL.h);
+        this.x = AL.random(0, AL.w);
     }
 
     setupConstantStyles() {
-        this.ctx.globalCompositeOperation = 'soft-light';
-        this.ctx.textAlign = 'center';
-        this.ctx.shadowBlur = 7;
-        this.ctx.lineWidth = 5;
+        AL.ctx.globalCompositeOperation = 'soft-light';
+        AL.ctx.textAlign = 'center';
+        AL.ctx.shadowBlur = 7;
+        AL.ctx.lineWidth = 5;
     }
 
     setupDrawingStyles() {
-        this.ctx.shadowColor = this.ctx.strokeStyle = AL.randomColor();
-        this.ctx.font = `bold ${this.size}px serif`;
-        this.ctx.fillStyle = AL.randomColor();
+        AL.ctx.shadowColor = AL.ctx.strokeStyle = AL.randomColor();
+        AL.ctx.font = `bold ${this.size}px serif`;
+        AL.ctx.fillStyle = AL.randomColor();
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.strokeText(
+            AL.ctx.strokeText(
                 `${this.letter1}   ${this.letter2}   ${this.letter3}   ${this.letter4}`,
                 this.x,
                 this.y,

--- a/src/algos/Cornucopia.js
+++ b/src/algos/Cornucopia.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Cornucopia extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Cornucopia';
 
@@ -13,8 +13,8 @@ export default class Cornucopia extends AL {
     }
 
     initializeProperties() {
-        this.x = AL.random(50, this.w - 50);
-        this.y = AL.random(50, this.h - 50);
+        this.x = AL.random(50, AL.w - 50);
+        this.y = AL.random(50, AL.h - 50);
         this.height = AL.random(15, 150);
         this.width = AL.random(15, 240);
         this.rotate = AL.random(3, 32);
@@ -25,13 +25,13 @@ export default class Cornucopia extends AL {
     }
 
     setupDrawingStyles() {
-        this.ctx.fillStyle = AL.randomColor(0, 255, 0.03, 0.1);
-        this.ctx.strokeStyle = AL.randomColor();
+        AL.ctx.fillStyle = AL.randomColor(0, 255, 0.03, 0.1);
+        AL.ctx.strokeStyle = AL.randomColor();
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.roundRectExtra(
+            AL.ctx.roundRectExtra(
                 this.x,
                 this.y,
                 this.width,

--- a/src/algos/Cornucopia2.js
+++ b/src/algos/Cornucopia2.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Cornucopia2 extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Cornucopia 2';
 
@@ -16,8 +16,8 @@ export default class Cornucopia2 extends AL {
         this.height = AL.random(35, 350);
         this.width = AL.random(35, 440);
         this.rotate = AL.random(1, 75);
-        this.x = AL.random(0, this.w);
-        this.y = AL.random(0, this.h);
+        this.x = AL.random(0, AL.w);
+        this.y = AL.random(0, AL.h);
         this.ul = AL.random(4, 135);
         this.ulc = AL.random(-5, 5);
         this.ur = AL.random(4, 135);
@@ -29,14 +29,14 @@ export default class Cornucopia2 extends AL {
     }
 
     setupDrawingStyles() {
-        this.ctx.setLineDash([AL.random(2, 20), AL.random(5, 25), AL.random(0, 30)]);
-        this.ctx.strokeStyle = AL.randomColor(0, 255, 0.75, 1);
-        this.ctx.fillStyle = AL.randomColor();
+        AL.ctx.setLineDash([AL.random(2, 20), AL.random(5, 25), AL.random(0, 30)]);
+        AL.ctx.strokeStyle = AL.randomColor(0, 255, 0.75, 1);
+        AL.ctx.fillStyle = AL.randomColor();
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.roundRectExtra(
+            AL.ctx.roundRectExtra(
                 this.x,
                 this.y,
                 this.width,

--- a/src/algos/CounterClock.js
+++ b/src/algos/CounterClock.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class CounterClock extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Counter Clock';
 
@@ -23,20 +23,20 @@ export default class CounterClock extends AL {
     }
 
     setupDrawingStyles() {
-        this.ctx.shadowColor = this.ctx.strokeStyle = this.color;
-        this.ctx.font = `${AL.random(75, 750)}px sans-serif`;
-        this.ctx.textAlign = 'center';
-        this.ctx.shadowBlur = 3;
-        this.ctx.lineWidth = 2;
+        AL.ctx.shadowColor = AL.ctx.strokeStyle = this.color;
+        AL.ctx.font = `${AL.random(75, 750)}px sans-serif`;
+        AL.ctx.textAlign = 'center';
+        AL.ctx.shadowBlur = 3;
+        AL.ctx.lineWidth = 2;
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.translate(this.w / 2, this.h / 2);
-            this.ctx.strokeText(`   ${this.letter}`, 0, 0);
-            this.ctx.rotate(-this.rotate);
-            this.ctx.translate(-this.w / 2, -this.h / 2);
-            this.ctx.beginPath();
+            AL.ctx.translate(AL.w / 2, AL.h / 2);
+            AL.ctx.strokeText(`   ${this.letter}`, 0, 0);
+            AL.ctx.rotate(-this.rotate);
+            AL.ctx.translate(-AL.w / 2, -AL.h / 2);
+            AL.ctx.beginPath();
         }
 
         this.t += 1;
@@ -44,20 +44,20 @@ export default class CounterClock extends AL {
         if (this.t % (this.speed * 45) === 0) {
             const col = Math.random();
             if (col < 0.125) {
-                this.ctx.lineWidth = 1;
-                this.ctx.shadowBlur = 5;
+                AL.ctx.lineWidth = 1;
+                AL.ctx.shadowBlur = 5;
                 this.color = 'white';
             } else if (col < 0.25) {
-                this.ctx.lineWidth = 3;
+                AL.ctx.lineWidth = 3;
                 this.color = 'black';
             } else {
-                this.ctx.shadowBlur = 3;
-                this.ctx.lineWidth = 2;
+                AL.ctx.shadowBlur = 3;
+                AL.ctx.lineWidth = 2;
                 this.color = AL.randomColor();
             }
 
-            this.ctx.font = `${AL.random(75, 750)}px sans-serif`;
-            this.ctx.shadowColor = this.ctx.strokeStyle = this.color;
+            AL.ctx.font = `${AL.random(75, 750)}px sans-serif`;
+            AL.ctx.shadowColor = AL.ctx.strokeStyle = this.color;
         }
 
         if (this.t % (this.speed * 450) === 0) {

--- a/src/algos/CrayonFunnel.js
+++ b/src/algos/CrayonFunnel.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class CrayonFunnel extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Crayon Funnel';
 
@@ -13,24 +13,24 @@ export default class CrayonFunnel extends AL {
     }
 
     initializeProperties() {
-        this.x = AL.random(this.w / 3, this.w * 0.66);
-        this.y = AL.random(this.h / 3, this.h * 0.66);
+        this.x = AL.random(AL.w / 3, AL.w * 0.66);
+        this.y = AL.random(AL.h / 3, AL.h * 0.66);
         this.increment = AL.random(1, 6);
         this.rotate = AL.random(1, 150);
         this.radius = AL.random(5, 60);
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = AL.randomColor(0, 255, 1, 1);
-        this.ctx.lineWidth = 2;
+        AL.ctx.strokeStyle = AL.randomColor(0, 255, 1, 1);
+        AL.ctx.lineWidth = 2;
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.beginPath();
-            this.ctx.arc(this.x, this.y, this.radius, 0, 2 * Math.PI);
+            AL.ctx.beginPath();
+            AL.ctx.arc(this.x, this.y, this.radius, 0, 2 * Math.PI);
             this.radius += this.increment;
-            this.ctx.stroke();
+            AL.ctx.stroke();
         }
 
         this.t += 1;
@@ -43,7 +43,7 @@ export default class CrayonFunnel extends AL {
             if (Math.random() < 0.5) {
                 this.strokeStyle = Math.random() < 0.5 ? 'white' : 'black';
             } else {
-                this.ctx.strokeStyle = AL.randomColor(0, 255, 1, 1);
+                AL.ctx.strokeStyle = AL.randomColor(0, 255, 1, 1);
             }
         }
 

--- a/src/algos/CrystalTiles.js
+++ b/src/algos/CrystalTiles.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class CrystalTiles extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Crystal Tiles';
 
@@ -43,28 +43,28 @@ export default class CrystalTiles extends AL {
     }
 
     setupDrawingStyles() {
-        this.ctx.globalCompositeOperation = 'overlay';
-        this.ctx.lineWidth = AL.random(1, 4);
-        this.ctx.strokeStyle = 'white';
+        AL.ctx.globalCompositeOperation = 'overlay';
+        AL.ctx.lineWidth = AL.random(1, 4);
+        AL.ctx.strokeStyle = 'white';
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.strokeRect(this.x, this.y, this.size, this.size);
-            this.ctx.fillStyle = AL.randomColor();
-            this.ctx.fillRect(this.x, this.y, this.size, this.size);
+            AL.ctx.strokeRect(this.x, this.y, this.size, this.size);
+            AL.ctx.fillStyle = AL.randomColor();
+            AL.ctx.fillRect(this.x, this.y, this.size, this.size);
 
             this.x += this.size;
-            if (this.x > this.w) {
+            if (this.x > AL.w) {
                 this.x = 0;
                 this.y += this.size;
             }
-            if (this.y > this.h) {
+            if (this.y > AL.h) {
                 this.x = 0;
                 this.y = 0;
                 this.size = AL.random(35, 150);
 
-                this.ctx.globalCompositeOperation = AL.pickRandomElement(this.modes);
+                AL.ctx.globalCompositeOperation = AL.pickRandomElement(this.modes);
 
                 this.rotateCanvasRadians(this.rotate);
             }

--- a/src/algos/DeepSea.js
+++ b/src/algos/DeepSea.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class DeepSea extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Deep Sea';
 
@@ -19,43 +19,36 @@ export default class DeepSea extends AL {
     }
 
     initializeProperties() {
-        this.startX = AL.random(0, this.w);
-        this.startY = AL.random(0, this.h);
-        this.cp1x = AL.random(0, this.w);
-        this.cp1y = AL.random(0, this.h);
-        this.cp2x = AL.random(0, this.w);
-        this.cp2y = AL.random(0, this.h);
-        this.endX = AL.random(0, this.w);
-        this.endY = AL.random(0, this.h);
+        this.startX = AL.random(0, AL.w);
+        this.startY = AL.random(0, AL.h);
+        this.cp1x = AL.random(0, AL.w);
+        this.cp1y = AL.random(0, AL.h);
+        this.cp2x = AL.random(0, AL.w);
+        this.cp2y = AL.random(0, AL.h);
+        this.endX = AL.random(0, AL.w);
+        this.endY = AL.random(0, AL.h);
         this.factor = AL.random(180, 850);
         this.factor2 = AL.random(36, 170);
         this.rotate = AL.pickRandomElement(this.rotations);
     }
 
     setupConstantStyles() {
-        this.ctx.lineWidth = 0.1;
-        this.ctx.fillStyle = 'rgba(0, 0, 0, 0.045)';
-        this.ctx.shadowBlur = 2;
+        AL.ctx.lineWidth = 0.1;
+        AL.ctx.fillStyle = 'rgba(0, 0, 0, 0.045)';
+        AL.ctx.shadowBlur = 2;
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = AL.randomColor(50, 200, 0.35, 0.7);
-        this.ctx.shadowColor = AL.randomColor(75, 200, 0.3, 0.5);
+        AL.ctx.strokeStyle = AL.randomColor(50, 200, 0.35, 0.7);
+        AL.ctx.shadowColor = AL.randomColor(75, 200, 0.3, 0.5);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
             this.fillScreen();
-            this.ctx.moveTo(this.startX, this.startY);
-            this.ctx.bezierCurveTo(
-                this.cp1x,
-                this.cp1y,
-                this.cp2x,
-                this.cp2y,
-                this.endX,
-                this.endY,
-            );
-            this.ctx.stroke();
+            AL.ctx.moveTo(this.startX, this.startY);
+            AL.ctx.bezierCurveTo(this.cp1x, this.cp1y, this.cp2x, this.cp2y, this.endX, this.endY);
+            AL.ctx.stroke();
 
             this.endX += Math.sin(this.t) * this.factor;
             this.endY += Math.cos(this.t) * this.factor;
@@ -70,7 +63,7 @@ export default class DeepSea extends AL {
         if (this.t % (this.speed * 270) === 0) {
             this.initializeProperties();
             this.setupDrawingStyles();
-            this.ctx.beginPath();
+            AL.ctx.beginPath();
         }
 
         this.requestFrame();

--- a/src/algos/DigitalArt.js
+++ b/src/algos/DigitalArt.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class DigitalArt extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Digital Art';
 
@@ -19,31 +19,31 @@ export default class DigitalArt extends AL {
 
     initializeProperties() {
         this.size = AL.random(12, 36);
-        this.x = AL.random(75, this.w - 75);
-        this.y = AL.random(30, this.h - 30);
+        this.x = AL.random(75, AL.w - 75);
+        this.y = AL.random(30, AL.h - 30);
     }
 
     setupDrawingStyles() {
-        this.ctx.fillStyle = AL.randomColor();
-        this.ctx.font = `${this.size}px serif`;
+        AL.ctx.fillStyle = AL.randomColor();
+        AL.ctx.font = `${this.size}px serif`;
     }
 
     draw() {
         if (this.t % this.speed === 0) {
             const letter = this.t % 2 ? '0' : '1';
-            this.ctx.font = `${this.size * 2}px serif`;
+            AL.ctx.font = `${this.size * 2}px serif`;
             if (this.t % 2) {
-                this.ctx.textAlign = 'left';
-                this.ctx.textBaseline = 'top';
-                this.ctx.fillText(`${letter}-`, this.w / 2, this.h / 2);
+                AL.ctx.textAlign = 'left';
+                AL.ctx.textBaseline = 'top';
+                AL.ctx.fillText(`${letter}-`, AL.w / 2, AL.h / 2);
             } else {
-                this.ctx.textAlign = 'right';
-                this.ctx.textBaseline = 'bottom';
-                this.ctx.fillText(`${letter}_`, this.w / 2, this.h / 2);
+                AL.ctx.textAlign = 'right';
+                AL.ctx.textBaseline = 'bottom';
+                AL.ctx.fillText(`${letter}_`, AL.w / 2, AL.h / 2);
             }
 
-            this.ctx.font = `${this.size}px serif`;
-            this.ctx.fillText(letter, this.x, this.y);
+            AL.ctx.font = `${this.size}px serif`;
+            AL.ctx.fillText(letter, this.x, this.y);
         }
 
         this.t += 1;

--- a/src/algos/Discos.js
+++ b/src/algos/Discos.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Discos extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Discos';
 
@@ -16,13 +16,13 @@ export default class Discos extends AL {
         this.color1 = AL.randomColor(5, 255, 0.5, 0.5);
         this.color2 = AL.randomColor(5, 255, 0.5, 0.5);
         this.startAngle = AL.random(0, 100);
-        this.radius = AL.random(10, this.h);
+        this.radius = AL.random(10, AL.h);
         this.endAngle = Math.PI;
         this.anti = false;
     }
 
     setupDrawingStyles() {
-        this.ctx.fillStyle = this.color1;
+        AL.ctx.fillStyle = this.color1;
     }
 
     draw() {
@@ -30,45 +30,45 @@ export default class Discos extends AL {
             this.stagger %= 3;
 
             if (this.stagger === 0) {
-                this.ctx.moveTo(this.w / 2, this.h / 2);
-                this.ctx.beginPath();
-                this.ctx.strokeStyle = this.color1;
-                this.ctx.lineWidth = AL.random(0, 100);
-                this.ctx.arc(
-                    this.w / 2,
-                    this.h / 2,
+                AL.ctx.moveTo(AL.w / 2, AL.h / 2);
+                AL.ctx.beginPath();
+                AL.ctx.strokeStyle = this.color1;
+                AL.ctx.lineWidth = AL.random(0, 100);
+                AL.ctx.arc(
+                    AL.w / 2,
+                    AL.h / 2,
                     this.radius,
                     this.startAngle,
                     this.endAngle,
                     this.anti,
                 );
-                this.ctx.stroke();
+                AL.ctx.stroke();
             }
 
             if (this.stagger === 1) {
-                this.ctx.beginPath();
-                this.ctx.strokeStyle = this.color2;
+                AL.ctx.beginPath();
+                AL.ctx.strokeStyle = this.color2;
                 this.anti = !this.anti;
-                this.radius = AL.random(0, this.h);
-                this.ctx.arc(
-                    this.w / 2,
-                    this.h / 2,
+                this.radius = AL.random(0, AL.h);
+                AL.ctx.arc(
+                    AL.w / 2,
+                    AL.h / 2,
                     this.radius,
                     this.startAngle,
                     this.endAngle,
                     this.anti,
                 );
-                this.ctx.stroke();
+                AL.ctx.stroke();
             }
 
             if (this.stagger === 2) {
-                this.ctx.beginPath();
-                this.radius = AL.random(0, this.h);
-                this.ctx.fillRect(this.w / 2, this.h / 2, this.w, 2);
-                this.ctx.stroke();
+                AL.ctx.beginPath();
+                this.radius = AL.random(0, AL.h);
+                AL.ctx.fillRect(AL.w / 2, AL.h / 2, AL.w, 2);
+                AL.ctx.stroke();
             }
 
-            this.ctx.closePath();
+            AL.ctx.closePath();
 
             this.stagger += 1;
         }
@@ -80,7 +80,7 @@ export default class Discos extends AL {
         }
 
         if (this.t % (this.speed * 200) === 0) {
-            this.color1 = this.ctx.fillStyle = AL.randomColor(5, 255, 0.5, 0.5);
+            this.color1 = AL.ctx.fillStyle = AL.randomColor(5, 255, 0.5, 0.5);
             this.color2 = AL.randomColor(5, 255, 0.5, 0.5);
         }
 

--- a/src/algos/Division.js
+++ b/src/algos/Division.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Division extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Division';
 
@@ -14,34 +14,34 @@ export default class Division extends AL {
     }
 
     initializeProperties() {
-        this.radius = AL.random(25, Math.min(this.w, this.h) / 2);
+        this.radius = AL.random(25, Math.min(AL.w, AL.h) / 2);
         this.circles = [6, 8, 10, 12, 16, 20, 24, 32, 40, 48];
         this.size = AL.pickRandomElement(this.circles);
         this.angle = 0;
     }
 
     setupConstantStyles() {
-        this.ctx.shadowColor = 'white';
-        this.ctx.shadowBlur = 7;
+        AL.ctx.shadowColor = 'white';
+        AL.ctx.shadowBlur = 7;
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = AL.randomColor();
-        this.ctx.shadowColor = 'white';
-        this.ctx.fillStyle = AL.randomColor();
+        AL.ctx.strokeStyle = AL.randomColor();
+        AL.ctx.shadowColor = 'white';
+        AL.ctx.fillStyle = AL.randomColor();
     }
 
     draw() {
         if (this.t % this.speed === 0) {
             for (let i = 0; i < this.circles.length; i++) {
                 this.angle = (i * Math.PI * 2) / this.circles.length;
-                const x = this.w / 2 + Math.cos(this.angle) * this.radius;
-                const y = this.h / 2 + Math.sin(this.angle) * this.radius;
+                const x = AL.w / 2 + Math.cos(this.angle) * this.radius;
+                const y = AL.h / 2 + Math.sin(this.angle) * this.radius;
 
-                this.ctx.beginPath();
-                this.ctx.arc(x, y, this.size, 0, 2 * Math.PI);
-                this.ctx.fill();
-                this.ctx.stroke();
+                AL.ctx.beginPath();
+                AL.ctx.arc(x, y, this.size, 0, 2 * Math.PI);
+                AL.ctx.fill();
+                AL.ctx.stroke();
             }
         }
 

--- a/src/algos/Dotted.js
+++ b/src/algos/Dotted.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Dotted extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Dotted';
 
@@ -13,20 +13,20 @@ export default class Dotted extends AL {
     }
 
     initializeProperties() {
-        this.vx1 = AL.random(0, this.w);
-        this.vx2 = AL.random(0, this.w);
-        this.vx3 = AL.random(0, this.w);
-        this.vy1 = AL.random(0, this.h);
-        this.vy2 = AL.random(0, this.h);
-        this.vy3 = AL.random(0, this.h);
+        this.vx1 = AL.random(0, AL.w);
+        this.vx2 = AL.random(0, AL.w);
+        this.vx3 = AL.random(0, AL.w);
+        this.vy1 = AL.random(0, AL.h);
+        this.vy2 = AL.random(0, AL.h);
+        this.vy3 = AL.random(0, AL.h);
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = AL.randomColor(5, 255, 0.75, 0.75);
-        this.ctx.fillStyle = AL.randomColor(5, 255, 0.015, 0.015);
-        this.ctx.globalCompositeOperation = 'overlay';
-        this.ctx.setLineDash([14, 6]);
-        this.ctx.lineWidth = 2;
+        AL.ctx.strokeStyle = AL.randomColor(5, 255, 0.75, 0.75);
+        AL.ctx.fillStyle = AL.randomColor(5, 255, 0.015, 0.015);
+        AL.ctx.globalCompositeOperation = 'overlay';
+        AL.ctx.setLineDash([14, 6]);
+        AL.ctx.lineWidth = 2;
     }
 
     draw() {
@@ -34,23 +34,23 @@ export default class Dotted extends AL {
             this.stagger %= 3;
 
             if (this.stagger === 0) {
-                this.ctx.moveTo(this.w / 2, this.h / 2);
-                this.ctx.lineTo(this.vx2, this.vy2);
-                this.ctx.stroke();
+                AL.ctx.moveTo(AL.w / 2, AL.h / 2);
+                AL.ctx.lineTo(this.vx2, this.vy2);
+                AL.ctx.stroke();
             }
 
             if (this.stagger === 1) {
-                this.ctx.lineTo(this.vx3, this.vy3);
-                this.ctx.stroke();
+                AL.ctx.lineTo(this.vx3, this.vy3);
+                AL.ctx.stroke();
             }
 
             if (this.stagger === 2) {
-                this.ctx.lineTo(this.vx1, this.vy1);
-                this.ctx.stroke();
+                AL.ctx.lineTo(this.vx1, this.vy1);
+                AL.ctx.stroke();
 
                 this.initializeProperties();
 
-                this.ctx.beginPath();
+                AL.ctx.beginPath();
             }
 
             this.stagger += 1;
@@ -59,20 +59,20 @@ export default class Dotted extends AL {
         this.t += 1;
 
         if (this.t % (this.speed * 5) === 0) {
-            this.ctx.fillRect(0, 0, this.w, this.h);
+            AL.ctx.fillRect(0, 0, AL.w, AL.h);
         }
 
         if (this.t % (this.speed * 70) === 0) {
-            this.ctx.setLineDash([AL.random(1, 20), AL.random(7, 50)]);
-            this.ctx.lineWidth = AL.random(1, 29);
+            AL.ctx.setLineDash([AL.random(1, 20), AL.random(7, 50)]);
+            AL.ctx.lineWidth = AL.random(1, 29);
         }
 
         if (this.t % (this.speed * 200) === 0) {
-            this.ctx.fillStyle = AL.randomColor(5, 255, 0.015, 0.015);
+            AL.ctx.fillStyle = AL.randomColor(5, 255, 0.015, 0.015);
         }
 
         if (this.t % (this.speed * 280) === 0) {
-            this.ctx.strokeStyle = AL.randomColor(5, 255, 0.75, 0.75);
+            AL.ctx.strokeStyle = AL.randomColor(5, 255, 0.75, 0.75);
         }
 
         this.requestFrame();

--- a/src/algos/Dye.js
+++ b/src/algos/Dye.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Dye extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Dye';
 
@@ -43,29 +43,29 @@ export default class Dye extends AL {
         this.color2 = { color: AL.randomColor() };
         this.color3 = { color: AL.randomColor() };
         this.color4 = { color: AL.randomColor() };
-        this.offsetX = AL.random(-this.w / 5 / 2, this.w / 5 / 2);
-        this.offsetY = AL.random(-this.h / 5 / 2, this.h / 5 / 2);
+        this.offsetX = AL.random(-AL.w / 5 / 2, AL.w / 5 / 2);
+        this.offsetY = AL.random(-AL.h / 5 / 2, AL.h / 5 / 2);
     }
 
     setupConstantStyles() {
-        // this.ctx.clearRect(0, 0, this.w, this.h);
-        this.ctx.globalCompositeOperation = 'soft-light';
+        // AL.ctx.clearRect(0, 0, AL.w, AL.h);
+        AL.ctx.globalCompositeOperation = 'soft-light';
     }
 
     setupDrawingStyles() {
-        this.ctx.font = `${this.font1.size}px bold serif`;
-        this.ctx.strokeStyle = this.color1.color;
-        this.ctx.fillStyle = this.color2.color;
-        this.ctx.lineWidth = this.line1.width;
+        AL.ctx.font = `${this.font1.size}px bold serif`;
+        AL.ctx.strokeStyle = this.color1.color;
+        AL.ctx.fillStyle = this.color2.color;
+        AL.ctx.lineWidth = this.line1.width;
     }
 
     draw() {
-        for (let i = -100; i <= this.w + 100; i += this.w / 5) {
-            for (let j = -100; j <= this.h + 100; j += this.h / 5) {
+        for (let i = -100; i <= AL.w + 100; i += AL.w / 5) {
+            for (let j = -100; j <= AL.h + 100; j += AL.h / 5) {
                 this.rotateCanvasRadians(this.rotate);
 
-                this.ctx.fillText(this.text, i + this.offsetX, j + this.offsetY);
-                this.ctx.strokeText(this.text, i + this.offsetX, j + this.offsetY);
+                AL.ctx.fillText(this.text, i + this.offsetX, j + this.offsetY);
+                AL.ctx.strokeText(this.text, i + this.offsetX, j + this.offsetY);
             }
         }
 
@@ -99,7 +99,7 @@ export default class Dye extends AL {
                 this.font1,
                 {
                     duration: AL.random(4, 10),
-                    onUpdate: () => (this.ctx.font = `${this.font1.size}px bold serif`),
+                    onUpdate: () => (AL.ctx.font = `${this.font1.size}px bold serif`),
                     size: this.font2.size,
                 },
                 '<',
@@ -109,7 +109,7 @@ export default class Dye extends AL {
                 {
                     color: this.color3.color,
                     duration: AL.random(3, 13),
-                    onUpdate: () => (this.ctx.strokeStyle = this.color1.color),
+                    onUpdate: () => (AL.ctx.strokeStyle = this.color1.color),
                 },
                 '<',
             )
@@ -118,7 +118,7 @@ export default class Dye extends AL {
                 {
                     color: this.color1.color,
                     duration: AL.random(3, 10),
-                    onUpdate: () => (this.ctx.fillStyle = this.color2.color),
+                    onUpdate: () => (AL.ctx.fillStyle = this.color2.color),
                 },
                 '<',
             )
@@ -126,7 +126,7 @@ export default class Dye extends AL {
                 this.line1,
                 {
                     duration: AL.random(2, 10),
-                    onUpdate: () => (this.ctx.lineWidth = this.line1.width),
+                    onUpdate: () => (AL.ctx.lineWidth = this.line1.width),
                     width: this.line2.width,
                 },
                 '<',

--- a/src/algos/DysonSpheres.js
+++ b/src/algos/DysonSpheres.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class DysonSpheres extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Dyson Spheres';
 
@@ -13,47 +13,47 @@ export default class DysonSpheres extends AL {
     }
 
     initializeProperties() {
-        this.length = AL.random(60, Math.max(this.h / 2, this.h - 60));
-        this.height = AL.random(20, this.h / 2 - 40);
+        this.length = AL.random(60, Math.max(AL.h / 2, AL.h - 60));
+        this.height = AL.random(20, AL.h / 2 - 40);
         this.rotate = AL.random(1, 6);
     }
 
     setupDrawingStyles() {
-        this.ctx.shadowBlur = 20;
-        this.ctx.shadowOffsetX = 1;
-        this.ctx.shadowOffsetY = 1;
-        this.ctx.shadowColor = this.ctx.strokeStyle = AL.randomColor(5, 255, 0.33, 0.33);
+        AL.ctx.shadowBlur = 20;
+        AL.ctx.shadowOffsetX = 1;
+        AL.ctx.shadowOffsetY = 1;
+        AL.ctx.shadowColor = AL.ctx.strokeStyle = AL.randomColor(5, 255, 0.33, 0.33);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.ellipse(this.w / 2, this.h / 2, this.length, this.height, this.rotate, 0, 0);
-            this.ctx.stroke();
+            AL.ctx.ellipse(AL.w / 2, AL.h / 2, this.length, this.height, this.rotate, 0, 0);
+            AL.ctx.stroke();
         }
 
         this.t += 1;
 
         if (this.t % (this.speed * 170) === 0) {
-            this.ctx.beginPath();
+            AL.ctx.beginPath();
 
             const color = Math.random();
             if (color < 0.2) {
-                this.ctx.shadowBlur = 10;
-                this.ctx.shadowOffsetX = 0;
-                this.ctx.shadowOffsetY = 0;
-                this.ctx.shadowColor = this.ctx.strokeStyle = 'black';
+                AL.ctx.shadowBlur = 10;
+                AL.ctx.shadowOffsetX = 0;
+                AL.ctx.shadowOffsetY = 0;
+                AL.ctx.shadowColor = AL.ctx.strokeStyle = 'black';
             } else if (color < 0.4) {
-                this.ctx.shadowBlur = 10;
-                this.ctx.shadowOffsetX = 0;
-                this.ctx.shadowOffsetY = 0;
-                this.ctx.shadowColor = this.ctx.strokeStyle = 'white';
+                AL.ctx.shadowBlur = 10;
+                AL.ctx.shadowOffsetX = 0;
+                AL.ctx.shadowOffsetY = 0;
+                AL.ctx.shadowColor = AL.ctx.strokeStyle = 'white';
             } else {
-                this.ctx.shadowBlur = 20;
-                this.ctx.shadowColor = this.ctx.strokeStyle = AL.randomColor(5, 255, 0.33, 0.33);
+                AL.ctx.shadowBlur = 20;
+                AL.ctx.shadowColor = AL.ctx.strokeStyle = AL.randomColor(5, 255, 0.33, 0.33);
             }
 
-            this.length = AL.random(60, Math.max(this.h / 2, this.h - 60));
-            this.height = AL.random(20, this.h / 2 - 40);
+            this.length = AL.random(60, Math.max(AL.h / 2, AL.h - 60));
+            this.height = AL.random(20, AL.h / 2 - 40);
         }
 
         this.rotate = AL.random(0, 360);

--- a/src/algos/Encoded.js
+++ b/src/algos/Encoded.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Encoded extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Encoded';
 
@@ -23,25 +23,25 @@ export default class Encoded extends AL {
     initializeProperties() {
         this.letter = AL.pickRandomElement(this.letters);
         this.size = AL.random(100, 340);
-        this.x = AL.random(this.size / 2, this.w - this.size / 2);
-        this.y = AL.random(this.size / 2, this.h - this.size / 2);
+        this.x = AL.random(this.size / 2, AL.w - this.size / 2);
+        this.y = AL.random(this.size / 2, AL.h - this.size / 2);
     }
 
     setupConstantStyles() {
-        this.ctx.shadowBlur = 10;
-        this.ctx.textAlign = 'center';
-        this.ctx.fillStyle = 'rgba(0,0,0,0.2)';
+        AL.ctx.shadowBlur = 10;
+        AL.ctx.textAlign = 'center';
+        AL.ctx.fillStyle = 'rgba(0,0,0,0.2)';
     }
 
     setupDrawingStyles() {
-        this.ctx.font = `bold ${this.size}px serif`;
-        this.ctx.shadowColor = this.ctx.strokeStyle = AL.randomColor(30, 255, 0.2, 0.6);
+        AL.ctx.font = `bold ${this.size}px serif`;
+        AL.ctx.shadowColor = AL.ctx.strokeStyle = AL.randomColor(30, 255, 0.2, 0.6);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.strokeText(this.letter, this.x, this.y);
-            this.ctx.fillText(this.letter, this.x, this.y);
+            AL.ctx.strokeText(this.letter, this.x, this.y);
+            AL.ctx.fillText(this.letter, this.x, this.y);
         }
 
         this.t += 1;

--- a/src/algos/Entropy.js
+++ b/src/algos/Entropy.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Entropy extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Entropy';
 
@@ -14,22 +14,22 @@ export default class Entropy extends AL {
 
     initializeProperties() {
         this.rotate = AL.random(1, 181);
-        this.width = AL.random(50, this.w);
-        this.height = AL.random(50, this.h);
+        this.width = AL.random(50, AL.w);
+        this.height = AL.random(50, AL.h);
 
-        this.ul = AL.random(10, Math.min(this.w, this.h));
-        this.ur = AL.random(10, Math.min(this.w, this.h));
-        this.ll = AL.random(10, Math.min(this.w, this.h));
-        this.lr = AL.random(10, Math.min(this.w, this.h));
+        this.ul = AL.random(10, Math.min(AL.w, AL.h));
+        this.ur = AL.random(10, Math.min(AL.w, AL.h));
+        this.ll = AL.random(10, Math.min(AL.w, AL.h));
+        this.lr = AL.random(10, Math.min(AL.w, AL.h));
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = AL.randomColor(0, 255, 1);
+        AL.ctx.strokeStyle = AL.randomColor(0, 255, 1);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.roundRectExtra(0, 0, this.width, this.height, {
+            AL.ctx.roundRectExtra(0, 0, this.width, this.height, {
                 lowerLeft: this.ll,
                 lowerRight: this.lr,
                 upperLeft: this.ul,
@@ -43,7 +43,7 @@ export default class Entropy extends AL {
             this.ll -= 1;
             this.lr -= 1;
 
-            this.ctx.roundRectExtra(this.w, this.h, this.height, this.width, {
+            AL.ctx.roundRectExtra(AL.w, AL.h, this.height, this.width, {
                 lowerLeft: this.ur,
                 lowerRight: this.ul,
                 upperLeft: this.lr,
@@ -60,14 +60,14 @@ export default class Entropy extends AL {
 
             const colorRoll = Math.random();
             if (colorRoll < 0.1) {
-                this.ctx.strokeStyle = 'black';
+                AL.ctx.strokeStyle = 'black';
             } else if (colorRoll < 0.2) {
-                this.ctx.strokeStyle = 'white';
+                AL.ctx.strokeStyle = 'white';
             } else {
-                this.ctx.strokeStyle = AL.randomColor(0, 255, 1);
+                AL.ctx.strokeStyle = AL.randomColor(0, 255, 1);
             }
 
-            this.ctx.beginPath();
+            AL.ctx.beginPath();
         }
 
         this.requestFrame();

--- a/src/algos/EpicRays.js
+++ b/src/algos/EpicRays.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class EpicRays extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Epic Rays';
 
@@ -24,16 +24,16 @@ export default class EpicRays extends AL {
     }
 
     initializeProperties() {
-        this.pointAx = AL.random(0, this.w);
-        this.pointAy = AL.random(0, this.h);
-        this.pointBx = AL.random(0, this.w);
-        this.pointBy = AL.random(0, this.h);
-        this.pointCx = AL.random(0, this.w);
-        this.pointCy = AL.random(0, this.h);
+        this.pointAx = AL.random(0, AL.w);
+        this.pointAy = AL.random(0, AL.h);
+        this.pointBx = AL.random(0, AL.w);
+        this.pointBy = AL.random(0, AL.h);
+        this.pointCx = AL.random(0, AL.w);
+        this.pointCy = AL.random(0, AL.h);
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = AL.randomColor(40, 255, 0.25, 0.5);
+        AL.ctx.strokeStyle = AL.randomColor(40, 255, 0.25, 0.5);
     }
 
     draw() {
@@ -41,24 +41,24 @@ export default class EpicRays extends AL {
             this.stagger %= 4;
 
             if (this.stagger === 0) {
-                this.ctx.beginPath();
-                this.ctx.moveTo(this.w / 2, this.h / 2);
-                this.ctx.lineTo(this.pointAx, this.pointAy);
-                this.ctx.stroke();
+                AL.ctx.beginPath();
+                AL.ctx.moveTo(AL.w / 2, AL.h / 2);
+                AL.ctx.lineTo(this.pointAx, this.pointAy);
+                AL.ctx.stroke();
             }
 
             if (this.stagger === 1) {
-                this.ctx.beginPath();
-                this.ctx.moveTo(this.pointAx, this.pointAy);
-                this.ctx.lineTo(this.pointBx, this.pointBy);
-                this.ctx.stroke();
+                AL.ctx.beginPath();
+                AL.ctx.moveTo(this.pointAx, this.pointAy);
+                AL.ctx.lineTo(this.pointBx, this.pointBy);
+                AL.ctx.stroke();
             }
 
             if (this.stagger === 2) {
-                this.ctx.beginPath();
-                this.ctx.moveTo(this.pointBx, this.pointBy);
-                this.ctx.lineTo(this.pointCx, this.pointCy);
-                this.ctx.stroke();
+                AL.ctx.beginPath();
+                AL.ctx.moveTo(this.pointBx, this.pointBy);
+                AL.ctx.lineTo(this.pointCx, this.pointCy);
+                AL.ctx.stroke();
             }
         }
 

--- a/src/algos/EvolvingMandala.js
+++ b/src/algos/EvolvingMandala.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class EvolvingMandala extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Evolving Mandala';
 
@@ -33,18 +33,14 @@ export default class EvolvingMandala extends AL {
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = AL.randomColor(20, 255, 0.85, 0.85);
-        this.ctx.font = `bold ${AL.random(70, 360)}px sans-serif`;
-        this.ctx.textAlign = 'center';
+        AL.ctx.strokeStyle = AL.randomColor(20, 255, 0.85, 0.85);
+        AL.ctx.font = `bold ${AL.random(70, 360)}px sans-serif`;
+        AL.ctx.textAlign = 'center';
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.strokeText(
-                `${this.letter} ${this.letter}  ${this.letter}`,
-                this.w / 2,
-                this.h / 2,
-            );
+            AL.ctx.strokeText(`${this.letter} ${this.letter}  ${this.letter}`, AL.w / 2, AL.h / 2);
 
             this.rotateCanvasDegrees(this.rotate);
         }
@@ -54,18 +50,18 @@ export default class EvolvingMandala extends AL {
         if (this.t % (this.speed * 45) === 0) {
             const pick = Math.random();
             if (pick < 0.075) {
-                this.ctx.strokeStyle = 'black';
+                AL.ctx.strokeStyle = 'black';
             } else if (pick < 0.15) {
-                this.ctx.strokeStyle = 'white';
+                AL.ctx.strokeStyle = 'white';
             } else {
-                this.ctx.strokeStyle = AL.randomColor(20, 255, 0.85, 0.85);
+                AL.ctx.strokeStyle = AL.randomColor(20, 255, 0.85, 0.85);
             }
 
             this.rotate += 2;
         }
 
         if (this.t % (this.speed * 90) === 0) {
-            this.ctx.font = `bold ${AL.random(70, 260)}px sans-serif`;
+            AL.ctx.font = `bold ${AL.random(70, 260)}px sans-serif`;
         }
 
         if (this.t % (this.speed * 360) === 0) {

--- a/src/algos/FadeIn.js
+++ b/src/algos/FadeIn.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class FadeIn extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Fade In';
 
@@ -14,14 +14,14 @@ export default class FadeIn extends AL {
 
     initializeProperties() {
         this.rotate = AL.random(1, 359);
-        this.x1 = AL.random(0, this.w);
-        this.y1 = AL.random(0, this.h);
-        this.x2 = AL.random(0, this.w);
-        this.y2 = AL.random(0, this.h);
-        this.ox = AL.random(0, this.w);
-        this.oy = AL.random(0, this.h);
-        this.dx = AL.random(0, this.w);
-        this.dy = AL.random(0, this.h);
+        this.x1 = AL.random(0, AL.w);
+        this.y1 = AL.random(0, AL.h);
+        this.x2 = AL.random(0, AL.w);
+        this.y2 = AL.random(0, AL.h);
+        this.ox = AL.random(0, AL.w);
+        this.oy = AL.random(0, AL.h);
+        this.dx = AL.random(0, AL.w);
+        this.dy = AL.random(0, AL.h);
         this.c1 = AL.random(-2, 2);
         this.c2 = AL.random(-2, 2);
         this.c3 = AL.random(-2, 2);
@@ -33,18 +33,18 @@ export default class FadeIn extends AL {
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = AL.randomColor();
-        this.ctx.globalAlpha = 0.15;
-        this.ctx.lineWidth = 0.2;
+        AL.ctx.strokeStyle = AL.randomColor();
+        AL.ctx.globalAlpha = 0.15;
+        AL.ctx.lineWidth = 0.2;
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.moveTo(this.ox, this.oy);
+            AL.ctx.moveTo(this.ox, this.oy);
             this.ox += this.c1;
             this.oy += this.c2;
-            this.ctx.bezierCurveTo(this.x1, this.y1, this.x2, this.y2, this.dx, this.dy);
-            this.ctx.stroke();
+            AL.ctx.bezierCurveTo(this.x1, this.y1, this.x2, this.y2, this.dx, this.dy);
+            AL.ctx.stroke();
 
             this.x1 += this.c3;
             this.y1 += this.c4;
@@ -61,8 +61,8 @@ export default class FadeIn extends AL {
         if (this.t % (this.speed * 150) === 0) {
             this.initializeProperties();
 
-            this.ctx.strokeStyle = AL.randomColor();
-            this.ctx.beginPath();
+            AL.ctx.strokeStyle = AL.randomColor();
+            AL.ctx.beginPath();
         }
 
         this.requestFrame();

--- a/src/algos/Fluor.js
+++ b/src/algos/Fluor.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Fluor extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Fluor';
 
@@ -15,31 +15,31 @@ export default class Fluor extends AL {
 
     initializeProperties() {
         this.rotate = AL.random(1, 359);
-        this.x1 = AL.random(0, this.w);
-        this.y1 = AL.random(0, this.h);
-        this.x2 = AL.random(0, this.w);
-        this.y2 = AL.random(0, this.h);
-        this.ox = AL.random(0, this.w);
-        this.oy = AL.random(0, this.h);
-        this.dx = AL.random(0, this.w);
-        this.dy = AL.random(0, this.h);
+        this.x1 = AL.random(0, AL.w);
+        this.y1 = AL.random(0, AL.h);
+        this.x2 = AL.random(0, AL.w);
+        this.y2 = AL.random(0, AL.h);
+        this.ox = AL.random(0, AL.w);
+        this.oy = AL.random(0, AL.h);
+        this.dx = AL.random(0, AL.w);
+        this.dy = AL.random(0, AL.h);
     }
 
     setupConstantStyles() {
-        this.ctx.globalCompositeOperation = 'overlay';
-        this.ctx.shadowBlur = 4;
-        this.ctx.lineWidth = 2;
+        AL.ctx.globalCompositeOperation = 'overlay';
+        AL.ctx.shadowBlur = 4;
+        AL.ctx.lineWidth = 2;
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = this.ctx.shadowColor = AL.randomColor();
+        AL.ctx.strokeStyle = AL.ctx.shadowColor = AL.randomColor();
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.moveTo(this.ox, this.oy);
-            this.ctx.bezierCurveTo(this.x1, this.y1, this.x2, this.y2, this.dx, this.dy);
-            this.ctx.stroke();
+            AL.ctx.moveTo(this.ox, this.oy);
+            AL.ctx.bezierCurveTo(this.x1, this.y1, this.x2, this.y2, this.dx, this.dy);
+            AL.ctx.stroke();
         }
 
         this.t += 1;
@@ -49,7 +49,7 @@ export default class Fluor extends AL {
         if (this.t % (this.speed * 180) === 0) {
             this.initializeProperties();
             this.setupDrawingStyles();
-            this.ctx.beginPath();
+            AL.ctx.beginPath();
         }
 
         this.requestFrame();

--- a/src/algos/FourDee.js
+++ b/src/algos/FourDee.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class FourDee extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Four Dee';
 
@@ -15,39 +15,39 @@ export default class FourDee extends AL {
     }
 
     initializeBaseProperties() {
-        this.springPoint = { x: this.w / 2, y: this.h / 2 };
+        this.springPoint = { x: AL.w / 2, y: AL.h / 2 };
     }
 
     initializeProperties() {
-        this.weight = AL.createParticle(AL.random(0, this.w), AL.random(0, this.h), 0, 0);
+        AL.weight = AL.createParticle(AL.random(0, AL.w), AL.random(0, AL.h), 0, 0);
         this.rotate = AL.random(-90, -1);
         this.k = Math.random();
     }
 
     setupConstantStyles() {
-        this.ctx.strokeStyle = AL.randomColor();
+        AL.ctx.strokeStyle = AL.randomColor();
         this.radius = 20;
     }
 
     setupDrawingStyles() {
-        this.ctx.fillStyle = AL.randomColor(40, 255, 0.1, 0.25);
+        AL.ctx.fillStyle = AL.randomColor(40, 255, 0.1, 0.25);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            const dx = this.springPoint.x - this.weight.x;
-            const dy = this.springPoint.y - this.weight.y;
+            const dx = this.springPoint.x - AL.weight.x;
+            const dy = this.springPoint.y - AL.weight.y;
             const distance = Math.hypot(dx, dy);
             const springForce = distance * this.k;
             const ax = (dx / distance) * springForce;
             const ay = (dy / distance) * springForce;
-            this.weight.vx += ax;
-            this.weight.vy += ay;
-            this.weight.update();
+            AL.weight.vx += ax;
+            AL.weight.vy += ay;
+            AL.weight.update();
 
-            this.ctx.beginPath();
-            this.ctx.arc(this.weight.x, this.weight.y, this.radius, 0, 2 * Math.PI);
-            this.ctx.fill();
+            AL.ctx.beginPath();
+            AL.ctx.arc(AL.weight.x, AL.weight.y, this.radius, 0, 2 * Math.PI);
+            AL.ctx.fill();
         }
 
         this.t += 1;
@@ -55,7 +55,7 @@ export default class FourDee extends AL {
         this.rotateCanvasRadians(this.rotate);
 
         if (this.t % (this.speed * 600) === 0) {
-            this.ctx.fillStyle = 'black';
+            AL.ctx.fillStyle = 'black';
             this.fillScreen();
 
             this.initializeProperties();

--- a/src/algos/Fruits.js
+++ b/src/algos/Fruits.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Fruits extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Fruits';
 
@@ -26,35 +26,35 @@ export default class Fruits extends AL {
     }
 
     setupConstantStyles() {
-        this.ctx.strokeStyle = 'black';
+        AL.ctx.strokeStyle = 'black';
     }
 
     setupDrawingStyles() {
-        this.ctx.fillStyle = AL.randomColor(0, 255, 0.1, 0.33);
+        AL.ctx.fillStyle = AL.randomColor(0, 255, 0.1, 0.33);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.arc(
+            AL.ctx.arc(
                 this.col * this.cell - this.cell,
                 this.row * this.cell - this.cell,
                 this.size,
                 0,
                 2 * Math.PI,
             );
-            this.ctx.stroke();
-            this.ctx.fill();
-            this.ctx.beginPath();
+            AL.ctx.stroke();
+            AL.ctx.fill();
+            AL.ctx.beginPath();
 
             this.col += 1;
-            if (this.col * this.cell - this.cell * 2 > this.w) {
+            if (this.col * this.cell - this.cell * 2 > AL.w) {
                 this.col = 0;
                 this.row += 1;
             }
-            if (this.row * this.cell - this.cell * 2 > this.h) {
+            if (this.row * this.cell - this.cell * 2 > AL.h) {
                 this.initializeProperties();
                 this.setupDrawingStyles();
-                this.ctx.beginPath();
+                AL.ctx.beginPath();
             }
         }
 

--- a/src/algos/GameOfFlies.js
+++ b/src/algos/GameOfFlies.js
@@ -12,8 +12,8 @@ import AL from '../AlgorithmLoader.js';
  */
 
 export default class GameOfFlies extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Game Of Flies';
 
@@ -23,12 +23,12 @@ export default class GameOfFlies extends AL {
     }
 
     initializeProperties() {
-        this.springPoint = { x: this.w / 2, y: this.h / 2 };
+        this.springPoint = { x: AL.w / 2, y: AL.h / 2 };
 
         /** @type {GameOfFliesParticle} */
         const particle = AL.createParticle(
-            AL.random(0, this.w),
-            AL.random(0, this.h),
+            AL.random(0, AL.w),
+            AL.random(0, AL.h),
             AL.random(5, 50),
             Math.random() * Math.PI * 2,
         );
@@ -40,8 +40,8 @@ export default class GameOfFlies extends AL {
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.fillStyle = 'rgba(0,0,0,0.14)';
-            this.ctx.fillRect(0, 0, this.w, this.h);
+            AL.ctx.fillStyle = 'rgba(0,0,0,0.14)';
+            AL.ctx.fillRect(0, 0, AL.w, AL.h);
 
             for (const particle of this.particles) {
                 const dx = this.springPoint.x - particle.x;
@@ -54,10 +54,10 @@ export default class GameOfFlies extends AL {
                 particle.vy += ay;
                 particle.update();
 
-                this.ctx.beginPath();
-                this.ctx.arc(particle.x, particle.y, particle.radius, 0, 2 * Math.PI);
-                this.ctx.fillStyle = particle.color;
-                this.ctx.fill();
+                AL.ctx.beginPath();
+                AL.ctx.arc(particle.x, particle.y, particle.radius, 0, 2 * Math.PI);
+                AL.ctx.fillStyle = particle.color;
+                AL.ctx.fill();
             }
         }
 
@@ -66,8 +66,8 @@ export default class GameOfFlies extends AL {
         if (this.t % (this.speed * 130) === 0) {
             /** @type {GameOfFliesParticle} */
             const newParticle = AL.createParticle(
-                AL.random(0, this.w),
-                AL.random(0, this.h),
+                AL.random(0, AL.w),
+                AL.random(0, AL.h),
                 AL.random(5, 50),
                 Math.random() * Math.PI * 2,
             );

--- a/src/algos/GasClouds.js
+++ b/src/algos/GasClouds.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class GasClouds extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Gas Clouds';
 
@@ -14,13 +14,13 @@ export default class GasClouds extends AL {
     }
 
     firstRunProperties() {
-        this.x = this.w / 2;
-        this.y = this.h / 2;
+        this.x = AL.w / 2;
+        this.y = AL.h / 2;
     }
 
     initializeProperties() {
-        this.width = AL.random(0, this.w / 2);
-        this.height = AL.random(0, this.h / 2);
+        this.width = AL.random(0, AL.w / 2);
+        this.height = AL.random(0, AL.h / 2);
         this.rotate = AL.random(1, 200);
         this.ul = AL.random(0, 300);
         this.ur = AL.random(0, 300);
@@ -31,13 +31,13 @@ export default class GasClouds extends AL {
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = AL.randomColor(0, 150, 0.2, 0.5);
-        this.ctx.fillStyle = AL.randomColor(25, 255, 0.02, 0.04);
+        AL.ctx.strokeStyle = AL.randomColor(0, 150, 0.2, 0.5);
+        AL.ctx.fillStyle = AL.randomColor(25, 255, 0.02, 0.04);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.roundRectExtra(
+            AL.ctx.roundRectExtra(
                 this.x,
                 this.y,
                 this.width,

--- a/src/algos/GenesisTypewriter.js
+++ b/src/algos/GenesisTypewriter.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class GenesisTypewriter extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Genesis Typewriter';
 
@@ -27,8 +27,8 @@ export default class GenesisTypewriter extends AL {
     }
 
     initializeProperties() {
-        this.pos1 = { x: AL.random(0, this.w), y: AL.random(0, this.h) };
-        this.pos2 = { x: AL.random(0, this.w), y: AL.random(0, this.h) };
+        this.pos1 = { x: AL.random(0, AL.w), y: AL.random(0, AL.h) };
+        this.pos2 = { x: AL.random(0, AL.w), y: AL.random(0, AL.h) };
         this.text = AL.pickRandomElement([...this.letters]);
         this.font2 = { size: AL.random(160, 600) };
         this.font1 = { size: AL.random(20, 100) };
@@ -38,18 +38,18 @@ export default class GenesisTypewriter extends AL {
     }
 
     setupConstantStyles() {
-        this.ctx.strokeStyle = 'white';
-        this.ctx.fillStyle = 'black';
+        AL.ctx.strokeStyle = 'white';
+        AL.ctx.fillStyle = 'black';
     }
 
     setupDrawingStyles() {
-        this.ctx.font = `${this.font1.size}px bold serif`;
-        this.ctx.lineWidth = this.line1.width;
+        AL.ctx.font = `${this.font1.size}px bold serif`;
+        AL.ctx.lineWidth = this.line1.width;
     }
 
     draw() {
-        this.ctx.fillText(this.text, this.pos1.x, this.pos1.y);
-        this.ctx.strokeText(this.text, this.pos1.x, this.pos1.y);
+        AL.ctx.fillText(this.text, this.pos1.x, this.pos1.y);
+        AL.ctx.strokeText(this.text, this.pos1.x, this.pos1.y);
 
         this.t += 1;
 
@@ -59,7 +59,7 @@ export default class GenesisTypewriter extends AL {
             this.initializeProperties();
 
             this.setupDrawingStyles();
-            this.ctx.strokeStyle = Math.random() < 0.25 ? 'white' : AL.randomColor();
+            AL.ctx.strokeStyle = Math.random() < 0.25 ? 'white' : AL.randomColor();
 
             this.getTweens();
         }
@@ -83,7 +83,7 @@ export default class GenesisTypewriter extends AL {
                 this.font1,
                 {
                     duration: AL.random(12, 40),
-                    onUpdate: () => (this.ctx.font = `${this.font1.size}px bold serif`),
+                    onUpdate: () => (AL.ctx.font = `${this.font1.size}px bold serif`),
                     size: this.font2.size,
                 },
                 '<',
@@ -108,7 +108,7 @@ export default class GenesisTypewriter extends AL {
                 this.line1,
                 {
                     duration: AL.random(6, 14),
-                    onUpdate: () => (this.ctx.lineWidth = this.line1.width),
+                    onUpdate: () => (AL.ctx.lineWidth = this.line1.width),
                     width: this.line2.width,
                 },
                 '<',

--- a/src/algos/Geometer.js
+++ b/src/algos/Geometer.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Geometer extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Geometer';
 
@@ -19,19 +19,19 @@ export default class Geometer extends AL {
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = AL.randomColor();
-        this.ctx.lineWidth = AL.random(2, 7);
-        this.ctx.shadowColor = 'black';
-        this.ctx.shadowBlur = 1;
+        AL.ctx.strokeStyle = AL.randomColor();
+        AL.ctx.lineWidth = AL.random(2, 7);
+        AL.ctx.shadowColor = 'black';
+        AL.ctx.shadowBlur = 1;
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.lineTo(this.w / 2 + this.change, this.h / 2 + this.change);
-            this.ctx.stroke();
+            AL.ctx.lineTo(AL.w / 2 + this.change, AL.h / 2 + this.change);
+            AL.ctx.stroke();
 
             this.change += this.rate;
-            if (Math.abs(this.change + this.rate) > Math.max(this.w / 2, this.h / 2)) {
+            if (Math.abs(this.change + this.rate) > Math.max(AL.w / 2, AL.h / 2)) {
                 this.rate = -this.rate;
             }
 
@@ -43,19 +43,19 @@ export default class Geometer extends AL {
         if (this.t % (this.speed * 180) === 0) {
             this.initializeProperties();
 
-            this.ctx.beginPath();
-            this.ctx.lineWidth = AL.random(2, 7);
+            AL.ctx.beginPath();
+            AL.ctx.lineWidth = AL.random(2, 7);
 
             const color = Math.random();
             if (color < 0.2) {
-                this.ctx.strokeStyle = 'white';
-                this.ctx.shadowColor = 'black';
+                AL.ctx.strokeStyle = 'white';
+                AL.ctx.shadowColor = 'black';
             } else if (color < 0.4) {
-                this.ctx.strokeStyle = 'black';
-                this.ctx.shadowColor = 'white';
+                AL.ctx.strokeStyle = 'black';
+                AL.ctx.shadowColor = 'white';
             } else {
-                this.ctx.strokeStyle = AL.randomColor();
-                this.ctx.shadowColor = 'black';
+                AL.ctx.strokeStyle = AL.randomColor();
+                AL.ctx.shadowColor = 'black';
             }
         }
 

--- a/src/algos/Germinate.js
+++ b/src/algos/Germinate.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Germinate extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Germinate';
 
@@ -23,31 +23,31 @@ export default class Germinate extends AL {
 
     initializeProperties() {
         this.rotate = AL.pickRandomElement(this.angles);
-        this.width = AL.random(35, this.w * 0.8);
-        this.height = AL.random(35, this.h * 0.8);
+        this.width = AL.random(35, AL.w * 0.8);
+        this.height = AL.random(35, AL.h * 0.8);
         this.ul = AL.random(4, 115);
         this.ur = AL.random(4, 115);
         this.dl = AL.random(4, 115);
         this.dr = AL.random(4, 115);
-        this.wc = AL.random(-5, 6);
-        this.hc = AL.random(-5, 6);
+        AL.wc = AL.random(-5, 6);
+        AL.hc = AL.random(-5, 6);
         this.rc = AL.random(-7, 8);
     }
 
     setupConstantStyles() {
-        this.ctx.shadowBlur = 2;
+        AL.ctx.shadowBlur = 2;
     }
 
     setupDrawingStyles() {
-        this.ctx.fillStyle = AL.randomColor(0, 255, 0.2, 0.2);
-        this.ctx.strokeStyle = this.ctx.shadowColor = AL.randomColor(0, 255, 1, 1);
+        AL.ctx.fillStyle = AL.randomColor(0, 255, 0.2, 0.2);
+        AL.ctx.strokeStyle = AL.ctx.shadowColor = AL.randomColor(0, 255, 1, 1);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.roundRectExtra(
-                this.w / 2,
-                this.h / 2,
+            AL.ctx.roundRectExtra(
+                AL.w / 2,
+                AL.h / 2,
                 this.width,
                 this.height,
                 {
@@ -65,14 +65,14 @@ export default class Germinate extends AL {
 
         if (this.t % (this.speed * 4) === 0) {
             this.ul += this.rc;
-            this.ur += this.wc;
-            this.dr += this.hc;
+            this.ur += AL.wc;
+            this.dr += AL.hc;
             this.dl -= this.rc;
         }
 
         if (this.t % (this.speed * 12) === 0) {
-            this.width -= this.wc;
-            this.height += this.hc;
+            this.width -= AL.wc;
+            this.height += AL.hc;
         }
 
         if (this.t % (this.speed * 280) === 0) {

--- a/src/algos/Glow.js
+++ b/src/algos/Glow.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Glow extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Glow';
 
@@ -16,22 +16,22 @@ export default class Glow extends AL {
         this.modes = ['color', 'source-over', 'overlay', 'soft-light'];
         this.color1 = AL.randomColor(0, 255, 0.05, 0.2);
         this.color2 = AL.randomColor(0, 255, 0.05, 0.2);
-        this.margin1 = AL.random(25, this.w / 4);
-        this.margin2 = AL.random(25, this.w / 4);
+        this.margin1 = AL.random(25, AL.w / 4);
+        this.margin2 = AL.random(25, AL.w / 4);
         this.rotate = AL.random(1, 60);
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = 'white';
-        this.ctx.globalCompositeOperation = 'color';
+        AL.ctx.strokeStyle = 'white';
+        AL.ctx.globalCompositeOperation = 'color';
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.fillStyle = this.color1;
-            this.ctx.fillRect(0, 0, this.w / 2 + this.margin1, this.h);
-            this.ctx.fillStyle = this.color2;
-            this.ctx.fillRect(this.w / 2 - this.margin2, 0, this.w, this.h);
+            AL.ctx.fillStyle = this.color1;
+            AL.ctx.fillRect(0, 0, AL.w / 2 + this.margin1, AL.h);
+            AL.ctx.fillStyle = this.color2;
+            AL.ctx.fillRect(AL.w / 2 - this.margin2, 0, AL.w, AL.h);
         }
 
         this.t += 1;
@@ -39,18 +39,18 @@ export default class Glow extends AL {
         this.rotateCanvasDegrees(this.rotate);
 
         if (this.t % (this.speed * 60) === 0) {
-            this.margin1 = AL.random(25, this.w / 4);
+            this.margin1 = AL.random(25, AL.w / 4);
             this.color1 = AL.randomColor(0, 255, 0.05, 0.2);
         }
 
         if (this.t % (this.speed * 90) === 0) {
-            this.margin2 = AL.random(25, this.w / 4);
+            this.margin2 = AL.random(25, AL.w / 4);
             this.color2 = AL.randomColor(0, 255, 0.05, 0.2);
         }
 
         if (this.t % (this.speed * 180) === 0) {
             this.rotate = AL.random(1, 60);
-            this.ctx.globalCompositeOperation = AL.pickRandomElement(this.modes);
+            AL.ctx.globalCompositeOperation = AL.pickRandomElement(this.modes);
         }
 
         this.requestFrame();

--- a/src/algos/Glowsticks.js
+++ b/src/algos/Glowsticks.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Glowsticks extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Glowsticks';
 
@@ -16,38 +16,38 @@ export default class Glowsticks extends AL {
     initializeProperties() {
         this.rotation = AL.random(1, 200);
         this.distance = AL.random(10, 100);
-        this.y = AL.random(this.distance, this.h);
-        this.x = AL.random(0, this.w - this.distance);
+        this.y = AL.random(this.distance, AL.h);
+        this.x = AL.random(0, AL.w - this.distance);
     }
 
     setupConstantStyles() {
-        this.ctx.shadowBlur = 5;
+        AL.ctx.shadowBlur = 5;
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = this.ctx.shadowColor = AL.randomColor();
+        AL.ctx.strokeStyle = AL.ctx.shadowColor = AL.randomColor();
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.moveTo(this.x, this.y);
-            this.ctx.lineTo(this.x + this.distance, this.y - this.distance);
-            this.ctx.stroke();
+            AL.ctx.moveTo(this.x, this.y);
+            AL.ctx.lineTo(this.x + this.distance, this.y - this.distance);
+            AL.ctx.stroke();
 
             this.x += 1;
             this.y += 1;
 
-            if (this.x > this.w) {
+            if (this.x > AL.w) {
                 this.x = 0;
             }
             if (this.x < 0) {
-                this.x = this.w - this.distance;
+                this.x = AL.w - this.distance;
             }
-            if (this.y > this.h) {
+            if (this.y > AL.h) {
                 this.y = this.distance;
             }
             if (this.y < 0) {
-                this.x = this.h;
+                this.x = AL.h;
             }
         }
 
@@ -58,7 +58,7 @@ export default class Glowsticks extends AL {
             this.setupDrawingStyles();
             this.clearScreen();
 
-            this.ctx.beginPath();
+            AL.ctx.beginPath();
         }
 
         this.rotateCanvasRadians(this.rotation);

--- a/src/algos/GravityTurbulence.js
+++ b/src/algos/GravityTurbulence.js
@@ -15,8 +15,8 @@ import AL from '../AlgorithmLoader.js';
  */
 
 export default class GravityTurbulence extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Gravity Turbulence';
 
@@ -30,7 +30,7 @@ export default class GravityTurbulence extends AL {
         /** @type {GravityTurbulenceParticle} */
         this.sun1 = AL.createParticle(150, 200, 1, Math.random() * Math.PI * 2);
         /** @type {GravityTurbulenceParticle} */
-        this.sun2 = AL.createParticle(this.w / 2, this.h / 2, 2, Math.random() * Math.PI * 2);
+        this.sun2 = AL.createParticle(AL.w / 2, AL.h / 2, 2, Math.random() * Math.PI * 2);
 
         this.sun1.radius = 40;
         this.sun2.radius = 30;
@@ -43,8 +43,8 @@ export default class GravityTurbulence extends AL {
         for (let i = 0; i < this.numParticles; i++) {
             /** @type {GravityTurbulenceParticle} */
             const particle = AL.createParticle(
-                AL.mathUtils.randomRange(0, this.w),
-                AL.mathUtils.randomRange(0, this.h),
+                AL.mathUtils.randomRange(0, AL.w),
+                AL.mathUtils.randomRange(0, AL.h),
                 AL.mathUtils.randomRange(7, 8),
                 Math.PI / 2 + AL.mathUtils.randomRange(-0.1, 0.1),
             );
@@ -61,44 +61,44 @@ export default class GravityTurbulence extends AL {
     }
 
     draw() {
-        this.ctx.fillStyle = 'rgba(0,0,0,0.7)';
-        this.ctx.fillRect(0, 0, this.w, this.h);
+        AL.ctx.fillStyle = 'rgba(0,0,0,0.7)';
+        AL.ctx.fillRect(0, 0, AL.w, AL.h);
 
         this.sun1.update();
         this.sun2.update();
 
-        if (this.sun1.x - this.sun1.radius > this.w) {
+        if (this.sun1.x - this.sun1.radius > AL.w) {
             this.sun1.x = -this.sun1.radius;
         }
         if (this.sun1.x + this.sun1.radius < 0) {
-            this.sun1.x = this.w + this.sun1.radius;
+            this.sun1.x = AL.w + this.sun1.radius;
         }
-        if (this.sun1.y - this.sun1.radius > this.h) {
+        if (this.sun1.y - this.sun1.radius > AL.h) {
             this.sun1.y = -this.sun1.radius;
         }
         if (this.sun1.y + this.sun1.radius < 0) {
-            this.sun1.y = this.h + this.sun1.radius;
+            this.sun1.y = AL.h + this.sun1.radius;
         }
-        if (this.sun2.x - this.sun2.radius > this.w) {
+        if (this.sun2.x - this.sun2.radius > AL.w) {
             this.sun2.x = -this.sun2.radius;
         }
         if (this.sun2.x + this.sun2.radius < 0) {
-            this.sun2.x = this.w + this.sun2.radius;
+            this.sun2.x = AL.w + this.sun2.radius;
         }
-        if (this.sun2.y - this.sun2.radius > this.h) {
+        if (this.sun2.y - this.sun2.radius > AL.h) {
             this.sun2.y = -this.sun2.radius;
         }
         if (this.sun2.y + this.sun2.radius < 0) {
-            this.sun2.y = this.h + this.sun2.radius;
+            this.sun2.y = AL.h + this.sun2.radius;
         }
 
         for (const particle of this.particles) {
             particle.update();
             this.drawPart(particle, 'white');
 
-            if (particle.x > this.w || particle.x < 0 || particle.y > this.h || particle.y < 0) {
-                particle.x = AL.mathUtils.randomRange(0, this.w);
-                particle.y = AL.mathUtils.randomRange(0, this.h);
+            if (particle.x > AL.w || particle.x < 0 || particle.y > AL.h || particle.y < 0) {
+                particle.x = AL.mathUtils.randomRange(0, AL.w);
+                particle.y = AL.mathUtils.randomRange(0, AL.h);
                 particle.setSpeed(AL.mathUtils.randomRange(7, 8));
                 particle.setHeading(Math.PI / 2 + AL.mathUtils.randomRange(-0.1, 0.1));
             }
@@ -122,9 +122,9 @@ export default class GravityTurbulence extends AL {
     }
 
     drawPart(particle, color) {
-        this.ctx.fillStyle = color;
-        this.ctx.beginPath();
-        this.ctx.arc(particle.x, particle.y, particle.radius, 0, 2 * Math.PI);
-        this.ctx.fill();
+        AL.ctx.fillStyle = color;
+        AL.ctx.beginPath();
+        AL.ctx.arc(particle.x, particle.y, particle.radius, 0, 2 * Math.PI);
+        AL.ctx.fill();
     }
 }

--- a/src/algos/Gridlock.js
+++ b/src/algos/Gridlock.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Gridlock extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Gridlock';
 
@@ -19,20 +19,20 @@ export default class Gridlock extends AL {
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = 'white';
-        this.ctx.moveTo(this.gap, this.gap);
+        AL.ctx.strokeStyle = 'white';
+        AL.ctx.moveTo(this.gap, this.gap);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.lineTo(this.gap, this.h - this.gap);
-            this.ctx.stroke();
-            this.ctx.lineTo(this.w - this.gap, this.h - this.gap);
-            this.ctx.stroke();
-            this.ctx.lineTo(this.w - this.gap, this.gap);
-            this.ctx.stroke();
-            this.ctx.lineTo(this.gap + this.increment, this.gap);
-            this.ctx.stroke();
+            AL.ctx.lineTo(this.gap, AL.h - this.gap);
+            AL.ctx.stroke();
+            AL.ctx.lineTo(AL.w - this.gap, AL.h - this.gap);
+            AL.ctx.stroke();
+            AL.ctx.lineTo(AL.w - this.gap, this.gap);
+            AL.ctx.stroke();
+            AL.ctx.lineTo(this.gap + this.increment, this.gap);
+            AL.ctx.stroke();
 
             this.gap += this.increment;
         }
@@ -46,10 +46,10 @@ export default class Gridlock extends AL {
             this.increment = this.gap;
 
             this.isWhite = !this.isWhite;
-            this.ctx.strokeStyle = this.isWhite ? 'white' : 'black';
+            AL.ctx.strokeStyle = this.isWhite ? 'white' : 'black';
 
-            this.ctx.lineWidth = AL.random(1, 7);
-            this.ctx.beginPath();
+            AL.ctx.lineWidth = AL.random(1, 7);
+            AL.ctx.beginPath();
         }
 
         this.requestFrame();

--- a/src/algos/Halfsies.js
+++ b/src/algos/Halfsies.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Halfsies extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Halfsies';
 
@@ -21,21 +21,21 @@ export default class Halfsies extends AL {
         this.width1 = AL.random(2, 11);
         this.width2 = AL.random(2, 11);
         this.radius = AL.random(40, 400);
-        this.x = AL.random(this.w / 2 - this.radius, this.w / 2 + this.radius);
-        this.y = AL.random(this.h / 2 - this.radius, this.h / 2 + this.radius);
+        this.x = AL.random(AL.w / 2 - this.radius, AL.w / 2 + this.radius);
+        this.y = AL.random(AL.h / 2 - this.radius, AL.h / 2 + this.radius);
     }
 
     draw() {
-        this.ctx.lineWidth = this.t % 2 ? this.width1 : this.width2;
-        this.ctx.strokeStyle = this.t % 2 ? 'black' : 'white';
+        AL.ctx.lineWidth = this.t % 2 ? this.width1 : this.width2;
+        AL.ctx.strokeStyle = this.t % 2 ? 'black' : 'white';
         this.counter = !this.counter;
-        this.ctx.globalCompositeOperation = this.t % 2 ? 'source-over' : 'difference';
+        AL.ctx.globalCompositeOperation = this.t % 2 ? 'source-over' : 'difference';
 
         if (this.t % this.speed === 0) {
-            this.ctx.beginPath();
-            this.ctx.arc(this.x, this.y, this.radius, 0, Math.PI, this.counter);
-            this.ctx.stroke();
-            this.ctx.closePath();
+            AL.ctx.beginPath();
+            AL.ctx.arc(this.x, this.y, this.radius, 0, Math.PI, this.counter);
+            AL.ctx.stroke();
+            AL.ctx.closePath();
         }
 
         this.t += 1;
@@ -44,7 +44,7 @@ export default class Halfsies extends AL {
 
         if (this.t % (this.speed * 120) === 0) {
             this.initializeProperties();
-            this.ctx.beginPath();
+            AL.ctx.beginPath();
         }
 
         this.requestFrame();

--- a/src/algos/Hallucinate.js
+++ b/src/algos/Hallucinate.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Hallucinate extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Hallucinate';
 
@@ -15,19 +15,19 @@ export default class Hallucinate extends AL {
     initializeProperties() {
         this.rows = AL.random(3, 17);
         this.rot = AL.random(1, 180);
-        this.height = this.h / this.rows;
+        this.height = AL.h / this.rows;
         this.colors = AL.generateRGBAPalette(this.rows);
     }
 
     setupDrawingStyles() {
-        this.ctx.globalCompositeOperation = 'soft-light';
+        AL.ctx.globalCompositeOperation = 'soft-light';
     }
 
     draw() {
         if (this.t % this.speed === 0) {
             for (let i = 0; i <= this.rows; i++) {
-                this.ctx.fillStyle = this.colors[i];
-                this.ctx.fillRect(-this.w, i * this.height, 3 * this.w, this.height);
+                AL.ctx.fillStyle = this.colors[i];
+                AL.ctx.fillRect(-AL.w, i * this.height, 3 * AL.w, this.height);
             }
         }
 

--- a/src/algos/Harmonie.js
+++ b/src/algos/Harmonie.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Harmonie extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Harmonie';
 
@@ -26,29 +26,29 @@ export default class Harmonie extends AL {
     }
 
     initializeProperties() {
-        this.x = AL.random(40, this.w - 40);
-        this.y = AL.random(25, this.h - 25);
+        this.x = AL.random(40, AL.w - 40);
+        this.y = AL.random(25, AL.h - 25);
         this.size = AL.random(20, 55);
     }
 
     setupConstantStyles() {
-        this.ctx.textAlign = 'center';
+        AL.ctx.textAlign = 'center';
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = AL.randomColor(35, 210, 0.2, 0.65);
-        this.ctx.fillStyle = AL.randomColor(35, 210, 0.2, 0.65);
-        this.ctx.font = `${this.size}px serif`;
+        AL.ctx.strokeStyle = AL.randomColor(35, 210, 0.2, 0.65);
+        AL.ctx.fillStyle = AL.randomColor(35, 210, 0.2, 0.65);
+        AL.ctx.font = `${this.size}px serif`;
     }
 
     draw() {
         if (this.t % this.speed === 0) {
             if (this.t % 2) {
-                this.ctx.strokeText(this.letter1, this.x, this.y);
+                AL.ctx.strokeText(this.letter1, this.x, this.y);
             } else {
-                this.ctx.fillText(this.letter2, this.x, this.y);
+                AL.ctx.fillText(this.letter2, this.x, this.y);
             }
-            this.ctx.font = `${this.size}px serif`;
+            AL.ctx.font = `${this.size}px serif`;
         }
 
         this.t += 1;

--- a/src/algos/Hive.js
+++ b/src/algos/Hive.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Hive extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Hive';
 
@@ -20,28 +20,28 @@ export default class Hive extends AL {
 
     initializeProperties() {
         this.rows = AL.random(3, 10);
-        this.height = this.h / this.rows;
+        this.height = AL.h / this.rows;
         this.rot = AL.pickRandomElement(this.angles);
     }
 
     setupConstantStyles() {
-        this.ctx.shadowBlur = 7;
-        this.ctx.lineWidth = AL.random(7, 18);
+        AL.ctx.shadowBlur = 7;
+        AL.ctx.lineWidth = AL.random(7, 18);
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = AL.randomColor();
-        this.ctx.shadowColor = AL.randomColor();
-        this.ctx.globalCompositeOperation = 'overlay';
+        AL.ctx.strokeStyle = AL.randomColor();
+        AL.ctx.shadowColor = AL.randomColor();
+        AL.ctx.globalCompositeOperation = 'overlay';
     }
 
     draw() {
         if (this.t % this.speed === 0) {
             for (let i = 0; i <= this.rows; i++) {
-                this.ctx.strokeRect(
-                    AL.random(0, this.w),
+                AL.ctx.strokeRect(
+                    AL.random(0, AL.w),
                     i * this.height,
-                    AL.random(0, this.w),
+                    AL.random(0, AL.w),
                     this.height,
                 );
             }
@@ -57,11 +57,11 @@ export default class Hive extends AL {
         }
 
         if (this.t % (this.speed * 500) === 0) {
-            this.ctx.globalCompositeOperation = 'difference';
+            AL.ctx.globalCompositeOperation = 'difference';
         }
 
         if (this.t % (this.speed * 1500) === 0) {
-            this.ctx.globalCompositeOperation = 'hard-light';
+            AL.ctx.globalCompositeOperation = 'hard-light';
         }
 
         this.requestFrame();

--- a/src/algos/Hubble.js
+++ b/src/algos/Hubble.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Hubble extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Hubble';
 
@@ -20,23 +20,23 @@ export default class Hubble extends AL {
     }
 
     setupDrawingStyles() {
-        this.ctx.filter = 'blur(5px)';
-        this.ctx.globalCompositeOperation = 'hard-light';
-        this.ctx.fillStyle = AL.randomColor(0, 255, 0.01, 0.05);
+        AL.ctx.filter = 'blur(5px)';
+        AL.ctx.globalCompositeOperation = 'hard-light';
+        AL.ctx.fillStyle = AL.randomColor(0, 255, 0.01, 0.05);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.fillRect(this.w / 2, this.h / 2, this.currentVal * 3, this.currentVal * 3);
-            this.ctx.fillRect(this.w / 2, this.h / 2, this.currentVal * 3, -this.currentVal * 3);
-            this.ctx.fillRect(this.w / 2, this.h / 2, -this.currentVal * 3, this.currentVal * 3);
-            this.ctx.fillRect(this.w / 2, this.h / 2, -this.currentVal * 3, -this.currentVal * 3);
+            AL.ctx.fillRect(AL.w / 2, AL.h / 2, this.currentVal * 3, this.currentVal * 3);
+            AL.ctx.fillRect(AL.w / 2, AL.h / 2, this.currentVal * 3, -this.currentVal * 3);
+            AL.ctx.fillRect(AL.w / 2, AL.h / 2, -this.currentVal * 3, this.currentVal * 3);
+            AL.ctx.fillRect(AL.w / 2, AL.h / 2, -this.currentVal * 3, -this.currentVal * 3);
 
             this.index += 1;
             if (this.index >= this.seq.length - 1) {
                 this.index = 0;
                 this.rotate = AL.random(1, 44);
-                this.ctx.fillStyle = AL.randomColor(0, 255, 0.01, 0.05);
+                AL.ctx.fillStyle = AL.randomColor(0, 255, 0.01, 0.05);
             }
             this.currentVal = this.seq[this.index];
         }

--- a/src/algos/HyperTunnel.js
+++ b/src/algos/HyperTunnel.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class HyperTunnel extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'HyperTunnel';
 
@@ -14,26 +14,26 @@ export default class HyperTunnel extends AL {
 
     initializeProperties() {
         this.rotate = AL.random(95, 175);
-        this.side = AL.random(25, Math.min(this.w, this.h));
+        this.side = AL.random(25, Math.min(AL.w, AL.h));
     }
 
     setupDrawingStyles() {
         this.setFillStyle();
-        this.ctx.strokeStyle = AL.randomColor(5, 255, 0.25, 0.25);
+        AL.ctx.strokeStyle = AL.randomColor(5, 255, 0.25, 0.25);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.beginPath();
-            this.ctx.moveTo(this.w / 2, this.h / 2);
-            this.ctx.lineTo(this.w / 2 - this.side / 2, this.h / 2 - this.side / 2);
-            this.ctx.stroke();
-            this.ctx.moveTo(this.w / 2, this.h / 2);
-            this.ctx.lineTo(this.w / 2 + this.side / 2, this.h / 2 - this.side / 2);
-            this.ctx.stroke();
-            this.ctx.lineTo(this.w / 2 - this.side / 2, this.h / 2 - this.side / 2);
-            this.ctx.stroke();
-            this.ctx.fill();
+            AL.ctx.beginPath();
+            AL.ctx.moveTo(AL.w / 2, AL.h / 2);
+            AL.ctx.lineTo(AL.w / 2 - this.side / 2, AL.h / 2 - this.side / 2);
+            AL.ctx.stroke();
+            AL.ctx.moveTo(AL.w / 2, AL.h / 2);
+            AL.ctx.lineTo(AL.w / 2 + this.side / 2, AL.h / 2 - this.side / 2);
+            AL.ctx.stroke();
+            AL.ctx.lineTo(AL.w / 2 - this.side / 2, AL.h / 2 - this.side / 2);
+            AL.ctx.stroke();
+            AL.ctx.fill();
 
             this.rotateCanvasDegrees(this.rotate);
         }
@@ -41,7 +41,7 @@ export default class HyperTunnel extends AL {
         this.t += 1;
 
         if (this.t % (this.speed * (360 / this.rotate)) === 0) {
-            this.side = AL.random(25, Math.min(this.w, this.h));
+            this.side = AL.random(25, Math.min(AL.w, AL.h));
             this.setupDrawingStyles();
         }
 
@@ -54,8 +54,8 @@ export default class HyperTunnel extends AL {
     }
 
     setFillStyle() {
-        this.ctx.fillStyle =
-            this.side > Math.min(this.w, this.h) / 2
+        AL.ctx.fillStyle =
+            this.side > Math.min(AL.w, AL.h) / 2
                 ? AL.randomColor(5, 255, 0.02, 0.02)
                 : AL.randomColor(5, 255, 0.2, 0.2);
     }

--- a/src/algos/Irradiate.js
+++ b/src/algos/Irradiate.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Irradiate extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Irradiate';
 
@@ -15,27 +15,27 @@ export default class Irradiate extends AL {
 
     initializeProperties() {
         this.rotate = AL.random(1, 181);
-        this.width = AL.random(50, this.w / 2);
-        this.height = AL.random(50, this.h / 2);
-        this.ul = AL.random(10, Math.min(this.w, this.h));
-        this.ur = AL.random(10, Math.min(this.w, this.h));
-        this.ll = AL.random(10, Math.min(this.w, this.h));
-        this.lr = AL.random(10, Math.min(this.w, this.h));
+        this.width = AL.random(50, AL.w / 2);
+        this.height = AL.random(50, AL.h / 2);
+        this.ul = AL.random(10, Math.min(AL.w, AL.h));
+        this.ur = AL.random(10, Math.min(AL.w, AL.h));
+        this.ll = AL.random(10, Math.min(AL.w, AL.h));
+        this.lr = AL.random(10, Math.min(AL.w, AL.h));
     }
 
     setupConstantStyles() {
-        this.ctx.globalCompositeOperation = 'hard-light';
+        AL.ctx.globalCompositeOperation = 'hard-light';
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = AL.randomColor(0, 255, 0.33);
+        AL.ctx.strokeStyle = AL.randomColor(0, 255, 0.33);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.roundRectExtra(
-                this.w / 2 - this.width / 2,
-                this.h / 2 - this.height / 2,
+            AL.ctx.roundRectExtra(
+                AL.w / 2 - this.width / 2,
+                AL.h / 2 - this.height / 2,
                 this.width,
                 this.height,
                 {
@@ -54,7 +54,7 @@ export default class Irradiate extends AL {
         if (this.t % (this.speed * 150) === 0) {
             this.initializeProperties();
             this.setupDrawingStyles();
-            this.ctx.beginPath();
+            AL.ctx.beginPath();
         }
 
         this.requestFrame();

--- a/src/algos/LisaJou.js
+++ b/src/algos/LisaJou.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class LisaJou extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'LisaJou';
 
@@ -13,8 +13,8 @@ export default class LisaJou extends AL {
     }
 
     initializeProperties() {
-        this.radiusX = AL.random(100, this.w * 0.75);
-        this.radiusY = AL.random(100, this.h * 0.75);
+        this.radiusX = AL.random(100, AL.w * 0.75);
+        this.radiusY = AL.random(100, AL.h * 0.75);
         this.speedX = Math.random() * 3;
         this.speedY = Math.random() * 3;
         this.size = AL.random(2, 16);
@@ -23,23 +23,23 @@ export default class LisaJou extends AL {
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = 'black';
-        this.ctx.fillStyle = AL.randomColor();
-        this.ctx.fillStyle = AL.randomColor();
-        this.ctx.fillRect(0, 0, this.w, this.h);
+        AL.ctx.strokeStyle = 'black';
+        AL.ctx.fillStyle = AL.randomColor();
+        AL.ctx.fillStyle = AL.randomColor();
+        AL.ctx.fillRect(0, 0, AL.w, AL.h);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            const x = this.w / 2 + Math.cos(this.angleX) * this.radiusX;
-            const y = this.h / 2 + Math.sin(this.angleY) * this.radiusY;
+            const x = AL.w / 2 + Math.cos(this.angleX) * this.radiusX;
+            const y = AL.h / 2 + Math.sin(this.angleY) * this.radiusY;
             this.angleX += this.speedX;
             this.angleY += this.speedY;
 
-            this.ctx.beginPath();
-            this.ctx.arc(x, y, this.size, 0, 2 * Math.PI);
-            this.ctx.fill();
-            this.ctx.stroke();
+            AL.ctx.beginPath();
+            AL.ctx.arc(x, y, this.size, 0, 2 * Math.PI);
+            AL.ctx.fill();
+            AL.ctx.stroke();
         }
 
         this.t += 1;

--- a/src/algos/Loading.js
+++ b/src/algos/Loading.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Loading extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Loading';
 
@@ -22,24 +22,24 @@ export default class Loading extends AL {
         this.rotate = AL.random(2, 45);
         this.width1 = AL.random(4, 51);
         this.width2 = AL.random(4, 51);
-        this.radius = AL.random(30, Math.max(this.w, this.h) / 2);
+        this.radius = AL.random(30, Math.max(AL.w, AL.h) / 2);
     }
 
     setupDrawingStyles() {
-        this.ctx.fillStyle = 'black';
+        AL.ctx.fillStyle = 'black';
         this.fillScreen();
     }
 
     draw() {
-        this.ctx.lineWidth = this.t % 2 ? this.width1 : this.width2;
-        this.ctx.strokeStyle = this.t % 2 ? 'black' : this.color;
+        AL.ctx.lineWidth = this.t % 2 ? this.width1 : this.width2;
+        AL.ctx.strokeStyle = this.t % 2 ? 'black' : this.color;
         this.counterClockwise = this.t % 2 === 1;
-        this.ctx.globalCompositeOperation = this.t % 2 ? 'source-over' : 'difference';
+        AL.ctx.globalCompositeOperation = this.t % 2 ? 'source-over' : 'difference';
 
         if (this.t % this.speed === 0) {
-            this.ctx.beginPath();
-            this.ctx.arc(this.w / 2, this.h / 2, this.radius, 0, Math.PI, this.counterClockwise);
-            this.ctx.stroke();
+            AL.ctx.beginPath();
+            AL.ctx.arc(AL.w / 2, AL.h / 2, this.radius, 0, Math.PI, this.counterClockwise);
+            AL.ctx.stroke();
         }
 
         this.t += 1;

--- a/src/algos/Lollipottery.js
+++ b/src/algos/Lollipottery.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Lollipottery extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Lollipottery';
 
@@ -14,33 +14,33 @@ export default class Lollipottery extends AL {
     }
 
     initializeProperties() {
-        this.radius = AL.random(50, Math.max(this.w, this.h) / 2);
+        this.radius = AL.random(50, Math.max(AL.w, AL.h) / 2);
         this.alter = AL.random(-50, 50);
     }
 
     setupConstantStyles() {
-        this.ctx.shadowBlur = 4;
+        AL.ctx.shadowBlur = 4;
     }
 
     setupDrawingStyles() {
-        this.ctx.lineWidth = AL.random(2, 14);
-        this.ctx.strokeStyle = AL.randomColor();
-        this.ctx.shadowColor = AL.randomColor();
-        this.ctx.globalCompositeOperation = 'overlay';
+        AL.ctx.lineWidth = AL.random(2, 14);
+        AL.ctx.strokeStyle = AL.randomColor();
+        AL.ctx.shadowColor = AL.randomColor();
+        AL.ctx.globalCompositeOperation = 'overlay';
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.arc(this.w / 2, this.h / 2, this.radius, 0, 2 * Math.PI);
+            AL.ctx.arc(AL.w / 2, AL.h / 2, this.radius, 0, 2 * Math.PI);
 
             this.radius += this.alter;
-            if (this.radius > Math.max(this.w, this.h) || this.radius <= 40) {
+            if (this.radius > Math.max(AL.w, AL.h) || this.radius <= 40) {
                 this.initializeProperties();
-                this.ctx.lineWidth = AL.random(2, 14);
+                AL.ctx.lineWidth = AL.random(2, 14);
             }
 
-            this.ctx.stroke();
-            this.ctx.beginPath();
+            AL.ctx.stroke();
+            AL.ctx.beginPath();
         }
 
         this.t += 1;
@@ -48,11 +48,11 @@ export default class Lollipottery extends AL {
         if (this.t % (this.speed * 150) === 0) {
             this.initializeProperties();
             this.setupDrawingStyles();
-            this.ctx.beginPath();
+            AL.ctx.beginPath();
         }
 
         if (this.t % (this.speed * 600) === 0) {
-            this.ctx.globalCompositeOperation = 'source-over';
+            AL.ctx.globalCompositeOperation = 'source-over';
         }
 
         this.requestFrame();

--- a/src/algos/Maelstrom.js
+++ b/src/algos/Maelstrom.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Maelstrom extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Maelstrom';
 
@@ -14,27 +14,27 @@ export default class Maelstrom extends AL {
     }
 
     initializeProperties() {
-        this.cp1 = AL.random(0, this.w);
-        this.cp2 = AL.random(0, this.h);
-        this.x1 = AL.random(0, this.w);
-        this.y1 = AL.random(0, this.h);
+        this.cp1 = AL.random(0, AL.w);
+        this.cp2 = AL.random(0, AL.h);
+        this.x1 = AL.random(0, AL.w);
+        this.y1 = AL.random(0, AL.h);
         this.angle = AL.random(1, 200);
     }
 
     setupConstantStyles() {
-        this.ctx.fillStyle = 'rgba(0, 0, 0, 0.225)';
-        this.ctx.lineWidth = 2;
+        AL.ctx.fillStyle = 'rgba(0, 0, 0, 0.225)';
+        AL.ctx.lineWidth = 2;
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = AL.randomColor(0, 255, 0.7, 1);
+        AL.ctx.strokeStyle = AL.randomColor(0, 255, 0.7, 1);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.moveTo(this.w / 2, this.h / 2);
-            this.ctx.quadraticCurveTo(this.cp1, this.cp2, this.x1, this.y1);
-            this.ctx.stroke();
+            AL.ctx.moveTo(AL.w / 2, AL.h / 2);
+            AL.ctx.quadraticCurveTo(this.cp1, this.cp2, this.x1, this.y1);
+            AL.ctx.stroke();
 
             this.x1 += 1;
             this.y1 += 1;
@@ -48,7 +48,7 @@ export default class Maelstrom extends AL {
             this.initializeProperties();
             this.setupDrawingStyles();
             this.fillScreen();
-            this.ctx.beginPath();
+            AL.ctx.beginPath();
         }
 
         this.requestFrame();

--- a/src/algos/Maelstrom2.js
+++ b/src/algos/Maelstrom2.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Maelstrom2 extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Maelstrom 2';
 
@@ -15,51 +15,51 @@ export default class Maelstrom2 extends AL {
 
     initializeProperties() {
         this.angle = AL.random(10, 350);
-        this.cp1 = AL.random(0, this.w);
-        this.cp2 = AL.random(0, this.h);
+        this.cp1 = AL.random(0, AL.w);
+        this.cp2 = AL.random(0, AL.h);
         this.alter1 = AL.random(-5, 5);
         this.alter2 = AL.random(-5, 5);
         this.alter3 = AL.random(-5, 5);
         this.alter4 = AL.random(-5, 5);
-        this.x1 = AL.random(0, this.w);
-        this.y1 = AL.random(0, this.h);
+        this.x1 = AL.random(0, AL.w);
+        this.y1 = AL.random(0, AL.h);
     }
 
     setupConstantStyles() {
-        this.ctx.lineWidth = 0.5;
+        AL.ctx.lineWidth = 0.5;
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = AL.randomColor(0, 255, 0.8, 1);
-        this.ctx.fillStyle = AL.randomColor(0, 160, 0.05, 0.15);
+        AL.ctx.strokeStyle = AL.randomColor(0, 255, 0.8, 1);
+        AL.ctx.fillStyle = AL.randomColor(0, 160, 0.05, 0.15);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.moveTo(this.w / 2, this.h / 2);
-            this.ctx.quadraticCurveTo(this.cp1, this.cp2, this.x1, this.y1);
+            AL.ctx.moveTo(AL.w / 2, AL.h / 2);
+            AL.ctx.quadraticCurveTo(this.cp1, this.cp2, this.x1, this.y1);
 
             this.cp1 += this.alter1;
-            if (this.cp1 > 2 * this.w || this.cp1 < -this.w) {
+            if (this.cp1 > 2 * AL.w || this.cp1 < -AL.w) {
                 this.alter1 = -this.alter1;
             }
 
             this.cp2 += this.alter2;
-            if (this.cp2 > 2 * this.h || this.cp2 < -this.h) {
+            if (this.cp2 > 2 * AL.h || this.cp2 < -AL.h) {
                 this.alter2 = -this.alter2;
             }
 
             this.x1 += this.alter3;
-            if (this.x1 > 2 * this.w || this.x1 < -this.w) {
+            if (this.x1 > 2 * AL.w || this.x1 < -AL.w) {
                 this.alter3 = -this.alter3;
             }
 
             this.y1 += this.alter4;
-            if (this.y1 > 2 * this.h || this.y1 < -this.h) {
+            if (this.y1 > 2 * AL.h || this.y1 < -AL.h) {
                 this.alter4 = -this.alter4;
             }
 
-            this.ctx.stroke();
+            AL.ctx.stroke();
             this.rotateCanvasDegrees(this.angle);
         }
 
@@ -69,7 +69,7 @@ export default class Maelstrom2 extends AL {
             this.initializeProperties();
             this.setupDrawingStyles();
             this.fillScreen();
-            this.ctx.beginPath();
+            AL.ctx.beginPath();
         }
 
         this.requestFrame();

--- a/src/algos/Majestic.js
+++ b/src/algos/Majestic.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Majestic extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Majestic';
 
@@ -22,24 +22,24 @@ export default class Majestic extends AL {
 
     initializeProperties() {
         this.rotate = AL.pickRandomElement(this.rotations);
-        this.width = AL.random(30, this.w - 100);
-        this.height = AL.random(30, this.h - 100);
-        this.x = AL.random(40, this.w - 40);
-        this.y = AL.random(40, this.h - 40);
-        this.ul = AL.random(10, this.w);
-        this.ur = AL.random(10, this.h);
-        this.ll = AL.random(10, this.h);
-        this.lr = AL.random(10, this.w);
+        this.width = AL.random(30, AL.w - 100);
+        this.height = AL.random(30, AL.h - 100);
+        this.x = AL.random(40, AL.w - 40);
+        this.y = AL.random(40, AL.h - 40);
+        this.ul = AL.random(10, AL.w);
+        this.ur = AL.random(10, AL.h);
+        this.ll = AL.random(10, AL.h);
+        this.lr = AL.random(10, AL.w);
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = AL.randomColor();
-        this.ctx.fillStyle = AL.randomColor(0, 255, 0.01, 0.05);
+        AL.ctx.strokeStyle = AL.randomColor();
+        AL.ctx.fillStyle = AL.randomColor(0, 255, 0.01, 0.05);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.roundRectExtra(
+            AL.ctx.roundRectExtra(
                 this.x,
                 this.y,
                 this.width,

--- a/src/algos/Matter.js
+++ b/src/algos/Matter.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Matter extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Matter';
 
@@ -21,12 +21,12 @@ export default class Matter extends AL {
     }
 
     initializeProperties() {
-        this.x1 = this.w / 2;
-        this.y1 = this.h / 2;
-        this.x2 = AL.random(0, this.w);
-        this.y2 = AL.random(0, this.h);
-        this.x3 = AL.random(0, this.w);
-        this.y3 = AL.random(0, this.h);
+        this.x1 = AL.w / 2;
+        this.y1 = AL.h / 2;
+        this.x2 = AL.random(0, AL.w);
+        this.y2 = AL.random(0, AL.h);
+        this.x3 = AL.random(0, AL.w);
+        this.y3 = AL.random(0, AL.h);
         this.radius1 = AL.random(5, 150);
         this.radius2 = AL.random(5, 150);
         this.radius3 = AL.random(5, 150);
@@ -34,20 +34,20 @@ export default class Matter extends AL {
     }
 
     setupDrawingStyles() {
-        this.ctx.fillStyle = AL.randomColor(10, 255, 0.02, 0.07);
+        AL.ctx.fillStyle = AL.randomColor(10, 255, 0.02, 0.07);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.beginPath();
-            this.ctx.arc(this.x1, this.y1, this.radius1, 0, 2 * Math.PI);
-            this.ctx.fill();
-            this.ctx.beginPath();
-            this.ctx.arc(this.x2, this.y2, this.radius2, 0, 2 * Math.PI);
-            this.ctx.fill();
-            this.ctx.beginPath();
-            this.ctx.arc(this.x3, this.y3, this.radius3, 0, 2 * Math.PI);
-            this.ctx.fill();
+            AL.ctx.beginPath();
+            AL.ctx.arc(this.x1, this.y1, this.radius1, 0, 2 * Math.PI);
+            AL.ctx.fill();
+            AL.ctx.beginPath();
+            AL.ctx.arc(this.x2, this.y2, this.radius2, 0, 2 * Math.PI);
+            AL.ctx.fill();
+            AL.ctx.beginPath();
+            AL.ctx.arc(this.x3, this.y3, this.radius3, 0, 2 * Math.PI);
+            AL.ctx.fill();
         }
 
         this.t += 1;

--- a/src/algos/Mesmerize.js
+++ b/src/algos/Mesmerize.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Mesmerize extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Mesmerize';
 
@@ -24,10 +24,10 @@ export default class Mesmerize extends AL {
         this.ur1 = AL.random(0, 30);
         this.ll1 = AL.random(0, 30);
         this.lr1 = AL.random(0, 30);
-        this.w1 = AL.random(30, 300);
-        this.h1 = AL.random(30, 300);
-        this.w2 = AL.random(60, 600);
-        this.h2 = AL.random(60, 600);
+        AL.w1 = AL.random(30, 300);
+        AL.h1 = AL.random(30, 300);
+        AL.w2 = AL.random(60, 600);
+        AL.h2 = AL.random(60, 600);
         this.ul2 = AL.random(-300, 600);
         this.ur2 = AL.random(-300, 600);
         this.ll2 = AL.random(-300, 600);
@@ -35,47 +35,47 @@ export default class Mesmerize extends AL {
         this.rotate = AL.random(1, 199);
         this.color2 = AL.randomColor(0, 127);
         this.color1 = AL.randomColor(127, 255);
-        this.x1 = AL.random(0, this.w - this.w1);
-        this.x2 = AL.random(0, this.w - this.w2);
-        this.y1 = AL.random(0, this.h - this.h1);
-        this.y2 = AL.random(0, this.h - this.h2);
+        this.x1 = AL.random(0, AL.w - AL.w1);
+        this.x2 = AL.random(0, AL.w - AL.w2);
+        this.y1 = AL.random(0, AL.h - AL.h1);
+        this.y2 = AL.random(0, AL.h - AL.h2);
         this.fill2 = AL.randomColor(0, 255, 0.04, 0.1);
         this.fill1 = AL.randomColor(0, 255, 0.01, 0.04);
 
         this.obj1 = {
             color: this.color1,
             fill: this.fill1,
-            height: this.h1,
+            height: AL.h1,
             lowerLeft: this.ll1,
             lowerRight: this.lr1,
             upperLeft: this.ul1,
             upperRight: this.ur1,
-            width: this.w1,
+            width: AL.w1,
             x: this.x1,
             y: this.y1,
         };
         this.obj2 = {
             color: this.color2,
             fill: this.fill2,
-            height: this.h2,
+            height: AL.h2,
             lowerLeft: this.ll2,
             lowerRight: this.lr2,
             upperLeft: this.ul2,
             upperRight: this.ur2,
-            width: this.w2,
+            width: AL.w2,
             x: this.x2,
             y: this.y2,
         };
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = this.obj1.color;
-        this.ctx.fillStyle = this.obj1.fill;
+        AL.ctx.strokeStyle = this.obj1.color;
+        AL.ctx.fillStyle = this.obj1.fill;
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.roundRectExtra(
+            AL.ctx.roundRectExtra(
                 this.obj1.width,
                 this.obj1.height,
                 this.obj1.x,
@@ -184,7 +184,7 @@ export default class Mesmerize extends AL {
                 {
                     color: this.obj2.color,
                     duration: AL.random(2, 20),
-                    onUpdate: () => (this.ctx.strokeStyle = this.obj1.color),
+                    onUpdate: () => (AL.ctx.strokeStyle = this.obj1.color),
                 },
                 '<',
             )
@@ -193,7 +193,7 @@ export default class Mesmerize extends AL {
                 {
                     duration: AL.random(2, 20),
                     fill: this.obj2.fill,
-                    onUpdate: () => (this.ctx.fillStyle = this.obj1.fill),
+                    onUpdate: () => (AL.ctx.fillStyle = this.obj1.fill),
                 },
                 '<',
             );

--- a/src/algos/Microscope.js
+++ b/src/algos/Microscope.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Microscope extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Microscope';
 
@@ -36,28 +36,28 @@ export default class Microscope extends AL {
     initializeProperties() {
         this.radiusX = AL.random(35, 415);
         this.radiusY = AL.random(35, 415);
-        this.rows = Math.ceil(this.h / this.radiusY) + 5;
-        this.cols = Math.ceil(this.w / this.radiusX) + 5;
+        this.rows = Math.ceil(AL.h / this.radiusY) + 5;
+        this.cols = Math.ceil(AL.w / this.radiusX) + 5;
     }
 
     setupConstantStyles() {
-        this.ctx.shadowBlur = 6;
+        AL.ctx.shadowBlur = 6;
     }
 
     setupDrawingStyles() {
-        this.ctx.shadowColor = this.ctx.strokeStyle = AL.randomColor(0, 255, 0.5, 0.5);
+        AL.ctx.shadowColor = AL.ctx.strokeStyle = AL.randomColor(0, 255, 0.5, 0.5);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
             for (let i = 0; i <= this.rows; i++) {
-                this.ctx.globalCompositeOperation = AL.pickRandomElement(this.modes);
+                AL.ctx.globalCompositeOperation = AL.pickRandomElement(this.modes);
 
                 this.rotateCanvasRadians(this.rotate);
 
                 for (let j = 0; j <= this.cols; j++) {
-                    this.ctx.beginPath();
-                    this.ctx.ellipse(
+                    AL.ctx.beginPath();
+                    AL.ctx.ellipse(
                         this.radiusX * j,
                         this.radiusY * i,
                         this.radiusX,
@@ -67,7 +67,7 @@ export default class Microscope extends AL {
                         2 * Math.PI,
                         false,
                     );
-                    this.ctx.stroke();
+                    AL.ctx.stroke();
                 }
             }
         }

--- a/src/algos/Mirage.js
+++ b/src/algos/Mirage.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Mirage extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Mirage';
 
@@ -18,19 +18,19 @@ export default class Mirage extends AL {
         this.ll = AL.random(10, 300);
         this.lr = AL.random(10, 300);
         this.rotate = AL.random(1, 50);
-        this.width = AL.random(100, this.w);
-        this.height = AL.random(100, this.h);
+        this.width = AL.random(100, AL.w);
+        this.height = AL.random(100, AL.h);
     }
 
     setupDrawingStyles() {
-        this.ctx.fillStyle = AL.randomColor(0, 255, 0.01, 0.05);
+        AL.ctx.fillStyle = AL.randomColor(0, 255, 0.01, 0.05);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.roundRectExtra(
-                this.w / 2 - this.width / 2,
-                this.h / 2 - this.height / 2,
+            AL.ctx.roundRectExtra(
+                AL.w / 2 - this.width / 2,
+                AL.h / 2 - this.height / 2,
                 this.width,
                 this.height,
                 {

--- a/src/algos/Nazca.js
+++ b/src/algos/Nazca.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Nazca extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Nazca';
 
@@ -26,19 +26,19 @@ export default class Nazca extends AL {
     }
 
     setupConstantStyles() {
-        this.ctx.globalCompositeOperation = 'soft-light';
+        AL.ctx.globalCompositeOperation = 'soft-light';
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = AL.randomColor(0, 255, 0.75, 1);
-        this.ctx.fillStyle = AL.randomColor(0, 255, 0.15, 0.55);
+        AL.ctx.strokeStyle = AL.randomColor(0, 255, 0.75, 1);
+        AL.ctx.fillStyle = AL.randomColor(0, 255, 0.15, 0.55);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.arc(this.w / 2, this.h / 2, this.radius, 0, Math.random() * Math.PI);
-            this.ctx.fill();
-            this.ctx.stroke();
+            AL.ctx.arc(AL.w / 2, AL.h / 2, this.radius, 0, Math.random() * Math.PI);
+            AL.ctx.fill();
+            AL.ctx.stroke();
             this.radius += this.increment;
         }
 
@@ -46,16 +46,16 @@ export default class Nazca extends AL {
 
         this.rotateCanvasRadians(-this.angle);
 
-        if (this.radius > Math.max(this.w, this.h)) {
+        if (this.radius > Math.max(AL.w, AL.h)) {
             this.cycles += 1;
             if (this.cycles % 10 === 0) {
-                this.ctx.globalCompositeOperation = AL.pickRandomElement(this.modes);
+                AL.ctx.globalCompositeOperation = AL.pickRandomElement(this.modes);
             }
 
             this.initializeProperties();
             this.setupDrawingStyles();
-            this.ctx.lineWidth = AL.random(1, 7);
-            this.ctx.beginPath();
+            AL.ctx.lineWidth = AL.random(1, 7);
+            AL.ctx.beginPath();
         }
 
         this.requestFrame();

--- a/src/algos/Nebulas.js
+++ b/src/algos/Nebulas.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Nebulas extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Nebulas';
 
@@ -16,28 +16,28 @@ export default class Nebulas extends AL {
     initializeProperties() {
         this.gap = AL.random(4, 100);
         this.rotate = AL.random(3, 160);
-        this.length = AL.random(50, Math.min(this.w, this.h) / 1.5);
+        this.length = AL.random(50, Math.min(AL.w, AL.h) / 1.5);
     }
 
     setupConstantStyles() {
-        this.ctx.shadowBlur = 15;
-        this.ctx.shadowOffsetX = 5;
-        this.ctx.shadowOffsetY = 5;
-        this.ctx.shadowColor = 'rgba(255,255,255,0.7)';
+        AL.ctx.shadowBlur = 15;
+        AL.ctx.shadowOffsetX = 5;
+        AL.ctx.shadowOffsetY = 5;
+        AL.ctx.shadowColor = 'rgba(255,255,255,0.7)';
     }
 
     setupDrawingStyles() {
-        this.ctx.fillStyle = this.ctx.strokeStyle = AL.randomColor(5, 255, 0.02, 0.02);
+        AL.ctx.fillStyle = AL.ctx.strokeStyle = AL.randomColor(5, 255, 0.02, 0.02);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.lineWidth = AL.random(1, 200);
-            this.ctx.strokeRect(this.w / 2, this.h / 2, this.length, this.gap);
+            AL.ctx.lineWidth = AL.random(1, 200);
+            AL.ctx.strokeRect(AL.w / 2, AL.h / 2, this.length, this.gap);
 
             this.rotateCanvasRadians(this.rotate);
 
-            this.length = AL.random(10, Math.max(this.w, this.h));
+            this.length = AL.random(10, Math.max(AL.w, AL.h));
             this.rotate = AL.random(3, 160);
             this.gap += AL.random(2, 10);
             if (this.gap > 1000) {
@@ -48,7 +48,7 @@ export default class Nebulas extends AL {
         this.t += 1;
 
         if (this.t % (this.speed * 10) === 0) {
-            this.ctx.fillRect(AL.random(0, this.w), AL.random(0, this.h), this.gap, this.gap);
+            AL.ctx.fillRect(AL.random(0, AL.w), AL.random(0, AL.h), this.gap, this.gap);
         }
 
         if (this.t % (this.speed * 70) === 0) {

--- a/src/algos/NeonTartans.js
+++ b/src/algos/NeonTartans.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class NeonTartans extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Neon Tartans';
 
@@ -14,9 +14,9 @@ export default class NeonTartans extends AL {
     initializeProperties() {
         this.color1 = AL.randomColor();
         this.color2 = AL.randomColor();
-        this.lineX = AL.random(0, this.h);
-        this.lineY = AL.random(0, this.w);
-        this.length = AL.random(50, Math.min(this.w, this.h) / 1.5);
+        this.lineX = AL.random(0, AL.h);
+        this.lineY = AL.random(0, AL.w);
+        this.length = AL.random(50, Math.min(AL.w, AL.h) / 1.5);
     }
 
     draw() {
@@ -24,30 +24,30 @@ export default class NeonTartans extends AL {
             this.stagger %= 3;
 
             if (this.stagger === 0) {
-                this.ctx.beginPath();
-                this.ctx.moveTo(0, this.lineX);
-                this.ctx.lineTo(this.w, this.lineX);
-                this.ctx.shadowBlur = 5;
-                this.ctx.shadowColor = this.ctx.strokeStyle = this.color1;
-                this.ctx.stroke();
+                AL.ctx.beginPath();
+                AL.ctx.moveTo(0, this.lineX);
+                AL.ctx.lineTo(AL.w, this.lineX);
+                AL.ctx.shadowBlur = 5;
+                AL.ctx.shadowColor = AL.ctx.strokeStyle = this.color1;
+                AL.ctx.stroke();
             }
 
             if (this.stagger === 1) {
-                this.ctx.beginPath();
-                this.ctx.moveTo(this.lineY, 0);
-                this.ctx.lineTo(this.lineY, this.h);
-                this.ctx.shadowBlur = 0;
-                this.ctx.shadowColor = this.ctx.strokeStyle = this.color2;
-                this.ctx.stroke();
+                AL.ctx.beginPath();
+                AL.ctx.moveTo(this.lineY, 0);
+                AL.ctx.lineTo(this.lineY, AL.h);
+                AL.ctx.shadowBlur = 0;
+                AL.ctx.shadowColor = AL.ctx.strokeStyle = this.color2;
+                AL.ctx.stroke();
             }
 
             if (this.stagger === 2) {
-                this.ctx.shadowBlur = 30;
-                this.ctx.beginPath();
-                this.ctx.lineWidth = 2;
-                this.ctx.arc(this.w / 2, this.h / 2, this.length, this.w, this.h);
-                this.ctx.stroke();
-                this.ctx.lineWidth = 1;
+                AL.ctx.shadowBlur = 30;
+                AL.ctx.beginPath();
+                AL.ctx.lineWidth = 2;
+                AL.ctx.arc(AL.w / 2, AL.h / 2, this.length, AL.w, AL.h);
+                AL.ctx.stroke();
+                AL.ctx.lineWidth = 1;
             }
 
             this.stagger += 1;
@@ -57,7 +57,7 @@ export default class NeonTartans extends AL {
 
         if (this.t % (this.speed * 15) === 0) {
             this.rotateCanvasDegrees(30);
-            this.length = AL.random(30, this.h / 2);
+            this.length = AL.random(30, AL.h / 2);
         }
 
         if (this.t % (this.speed * 180) === 0) {
@@ -65,8 +65,8 @@ export default class NeonTartans extends AL {
             this.color2 = AL.randomColor(0, 255, 1, 1);
         }
 
-        this.lineX = AL.random(0, this.h);
-        this.lineY = AL.random(0, this.w);
+        this.lineX = AL.random(0, AL.h);
+        this.lineY = AL.random(0, AL.w);
 
         this.requestFrame();
     }

--- a/src/algos/Networks.js
+++ b/src/algos/Networks.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Networks extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Networks';
 
@@ -14,8 +14,8 @@ export default class Networks extends AL {
     }
 
     initializeBaseProperties() {
-        this.x = this.w / 2;
-        this.y = this.h / 2;
+        this.x = AL.w / 2;
+        this.y = AL.h / 2;
     }
 
     initializeProperties() {
@@ -26,17 +26,17 @@ export default class Networks extends AL {
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = AL.randomColor();
+        AL.ctx.strokeStyle = AL.randomColor();
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.arc(this.x, this.y, this.size, 0, this.drawAmount * Math.PI * 2);
-            this.ctx.stroke();
+            AL.ctx.arc(this.x, this.y, this.size, 0, this.drawAmount * Math.PI * 2);
+            AL.ctx.stroke();
 
             this.drawAmount += 0.001;
             this.size += this.sizeIncrease;
-            this.ctx.beginPath();
+            AL.ctx.beginPath();
         }
 
         this.t += 1;
@@ -44,8 +44,8 @@ export default class Networks extends AL {
         this.rotateCanvasRadians(this.rotate);
 
         if (this.t % (this.speed * 480) === 0) {
-            this.x = AL.random(0, this.w);
-            this.y = AL.random(0, this.h);
+            this.x = AL.random(0, AL.w);
+            this.y = AL.random(0, AL.h);
 
             this.initializeProperties();
             this.setupDrawingStyles();

--- a/src/algos/Offsets.js
+++ b/src/algos/Offsets.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Offsets extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Offsets';
 
@@ -14,16 +14,16 @@ export default class Offsets extends AL {
 
     initializeProperties() {
         this.rotate = AL.random(7, 27);
-        this.length = AL.random(20, Math.max(this.w, this.h));
+        this.length = AL.random(20, Math.max(AL.w, AL.h));
     }
 
     setupDrawingStyles() {
-        this.ctx.shadowBlur = 3;
-        this.ctx.fillStyle = AL.randomColor();
-        this.ctx.shadowColor = AL.randomColor();
-        this.ctx.shadowOffsetX = AL.random(-200, 200);
-        this.ctx.shadowOffsetY = AL.random(-200, 200);
-        this.ctx.strokeStyle = AL.randomColor(0, 255, 0.1, 0.1);
+        AL.ctx.shadowBlur = 3;
+        AL.ctx.fillStyle = AL.randomColor();
+        AL.ctx.shadowColor = AL.randomColor();
+        AL.ctx.shadowOffsetX = AL.random(-200, 200);
+        AL.ctx.shadowOffsetY = AL.random(-200, 200);
+        AL.ctx.strokeStyle = AL.randomColor(0, 255, 0.1, 0.1);
     }
 
     draw() {
@@ -31,13 +31,13 @@ export default class Offsets extends AL {
             this.stagger %= 2;
 
             if (this.stagger === 0) {
-                this.ctx.lineTo(this.w / 2 - this.length, this.h / 2);
-                this.ctx.stroke();
+                AL.ctx.lineTo(AL.w / 2 - this.length, AL.h / 2);
+                AL.ctx.stroke();
             }
 
             if (this.stagger === 1) {
-                this.ctx.lineTo(this.w / 2, this.h / 2 - this.length);
-                this.ctx.stroke();
+                AL.ctx.lineTo(AL.w / 2, AL.h / 2 - this.length);
+                AL.ctx.stroke();
             }
 
             this.rotateCanvasRadians(this.rotate);
@@ -48,20 +48,20 @@ export default class Offsets extends AL {
         this.t += 1;
 
         if (this.t % (this.speed * 40) === 0) {
-            this.ctx.fill();
-            this.ctx.beginPath();
-            this.ctx.fillStyle = AL.randomColor();
-            this.length = AL.random(20, Math.max(this.w, this.h));
+            AL.ctx.fill();
+            AL.ctx.beginPath();
+            AL.ctx.fillStyle = AL.randomColor();
+            this.length = AL.random(20, Math.max(AL.w, AL.h));
         }
 
         if (this.t % (this.speed * 200) === 0) {
-            this.ctx.shadowColor = AL.randomColor();
-            this.ctx.shadowOffsetX = AL.random(-200, 200);
-            this.ctx.shadowOffsetY = AL.random(-200, 200);
+            AL.ctx.shadowColor = AL.randomColor();
+            AL.ctx.shadowOffsetX = AL.random(-200, 200);
+            AL.ctx.shadowOffsetY = AL.random(-200, 200);
         }
 
         if (this.t % (this.speed * 400) === 0) {
-            this.ctx.strokeStyle = AL.randomColor(0, 255, 0.1, 0.1);
+            AL.ctx.strokeStyle = AL.randomColor(0, 255, 0.1, 0.1);
             this.rotate = AL.random(1, 37);
         }
 

--- a/src/algos/Onion.js
+++ b/src/algos/Onion.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Onion extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Onion';
 
@@ -19,26 +19,26 @@ export default class Onion extends AL {
     }
 
     initializeProperties() {
-        this.x = AL.random(0, this.w);
-        this.y = AL.random(0, this.h);
+        this.x = AL.random(0, AL.w);
+        this.y = AL.random(0, AL.h);
         this.radius = AL.random(45, 500);
     }
 
     setupConstantStyles() {
-        this.ctx.strokeStyle = 'black';
+        AL.ctx.strokeStyle = 'black';
     }
 
     setupDrawingStyles() {
-        this.ctx.fillStyle = AL.randomColor(0, 255, 0.005, 0.015);
+        AL.ctx.fillStyle = AL.randomColor(0, 255, 0.005, 0.015);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.beginPath();
-            this.ctx.arc(this.x, this.y, this.radius, 0, 2 * Math.PI);
-            this.ctx.stroke();
-            this.ctx.fill();
-            this.ctx.closePath();
+            AL.ctx.beginPath();
+            AL.ctx.arc(this.x, this.y, this.radius, 0, 2 * Math.PI);
+            AL.ctx.stroke();
+            AL.ctx.fill();
+            AL.ctx.closePath();
         }
 
         this.t += 1;
@@ -48,7 +48,7 @@ export default class Onion extends AL {
         if (this.t % (this.speed * 135) === 0) {
             this.initializeProperties();
             this.setupDrawingStyles();
-            this.ctx.beginPath();
+            AL.ctx.beginPath();
         }
 
         if (this.t % (this.speed * 540) === 0) {

--- a/src/algos/Orbits.js
+++ b/src/algos/Orbits.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Orbits extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Orbits';
 
@@ -20,19 +20,19 @@ export default class Orbits extends AL {
 
     initializeProperties() {
         this.startAngle = AL.random(0, 100);
-        this.radius = AL.random(30, this.h);
+        this.radius = AL.random(30, AL.h);
         this.radius2 = AL.random(10, this.radius);
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = AL.randomColor(5, 255, 0.2, 0.2);
+        AL.ctx.strokeStyle = AL.randomColor(5, 255, 0.2, 0.2);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.ellipse(
-                this.w / 2,
-                this.h / 2,
+            AL.ctx.ellipse(
+                AL.w / 2,
+                AL.h / 2,
                 this.radius,
                 this.radius2,
                 this.rotate,
@@ -40,7 +40,7 @@ export default class Orbits extends AL {
                 this.endAngle,
             );
         }
-        this.ctx.stroke();
+        AL.ctx.stroke();
 
         this.t += 1;
 
@@ -51,7 +51,7 @@ export default class Orbits extends AL {
             this.rotate = AL.random(-3, 3);
 
             this.setupDrawingStyles();
-            this.ctx.beginPath();
+            AL.ctx.beginPath();
         }
 
         this.requestFrame();

--- a/src/algos/Organic.js
+++ b/src/algos/Organic.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Organic extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Organic';
 
@@ -15,8 +15,8 @@ export default class Organic extends AL {
 
     initializeBaseProperties() {
         this.decrease = 0.99;
-        this.side1 = this.w / 2;
-        this.side2 = this.h / 2;
+        this.side1 = AL.w / 2;
+        this.side2 = AL.h / 2;
     }
 
     initializeProperties() {
@@ -28,18 +28,18 @@ export default class Organic extends AL {
     }
 
     setupDrawingStyles() {
-        this.ctx.lineWidth = AL.random(6, 36);
-        this.ctx.fillStyle = AL.randomColor(0, 255, 0.1, 0.45);
-        this.ctx.strokeStyle = AL.randomColor(0, 255, 0.1, 0.45);
+        AL.ctx.lineWidth = AL.random(6, 36);
+        AL.ctx.fillStyle = AL.randomColor(0, 255, 0.1, 0.45);
+        AL.ctx.strokeStyle = AL.randomColor(0, 255, 0.1, 0.45);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.translate(this.w / 2, this.h / 2);
-            this.ctx.rotate(this.rotate);
-            this.ctx.roundRectExtra(
-                this.ctx.lineWidth - 2,
-                this.ctx.lineWidth - 2,
+            AL.ctx.translate(AL.w / 2, AL.h / 2);
+            AL.ctx.rotate(this.rotate);
+            AL.ctx.roundRectExtra(
+                AL.ctx.lineWidth - 2,
+                AL.ctx.lineWidth - 2,
                 this.side1,
                 this.side2,
                 {
@@ -51,14 +51,14 @@ export default class Organic extends AL {
                 true,
                 true,
             );
-            this.ctx.translate(-this.w / 2, -this.h / 2);
+            AL.ctx.translate(-AL.w / 2, -AL.h / 2);
 
             this.side1 *= this.decrease;
             this.side2 *= this.decrease;
             if (this.side1 < 10 || this.side2 < 10) {
                 this.decrease = 1.01;
             }
-            if (this.side1 > this.w || this.side2 > this.h) {
+            if (this.side1 > AL.w || this.side2 > AL.h) {
                 this.decrease = 0.99;
             }
         }
@@ -68,7 +68,7 @@ export default class Organic extends AL {
         if (this.t % (this.speed * 250) === 0) {
             this.initializeProperties();
             this.setupDrawingStyles();
-            this.ctx.beginPath();
+            AL.ctx.beginPath();
         }
 
         this.requestFrame();

--- a/src/algos/Ourobouros.js
+++ b/src/algos/Ourobouros.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Ourobouros extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Ourobouros';
 
@@ -24,24 +24,24 @@ export default class Ourobouros extends AL {
 
     initializeProperties() {
         this.rotate = AL.random(4, 30);
-        this.x = AL.random(100, this.w - 100);
-        this.y = AL.random(100, this.h - 100);
+        this.x = AL.random(100, AL.w - 100);
+        this.y = AL.random(100, AL.h - 100);
     }
 
     setupConstantStyles() {
-        this.ctx.lineWidth = 20;
-        this.ctx.textAlign = 'center';
-        this.ctx.globalCompositeOperation = 'difference';
+        AL.ctx.lineWidth = 20;
+        AL.ctx.textAlign = 'center';
+        AL.ctx.globalCompositeOperation = 'difference';
     }
 
     setupDrawingStyles() {
-        this.ctx.font = `${AL.random(40, 300)}px sans-serif`;
-        this.ctx.strokeStyle = AL.randomColor(0, 255, 0.08, 0.4);
+        AL.ctx.font = `${AL.random(40, 300)}px sans-serif`;
+        AL.ctx.strokeStyle = AL.randomColor(0, 255, 0.08, 0.4);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.strokeText(this.letter, this.x, this.y);
+            AL.ctx.strokeText(this.letter, this.x, this.y);
         }
 
         this.t += 1;

--- a/src/algos/PaletteSquares.js
+++ b/src/algos/PaletteSquares.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class PaletteSquares extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'PaletteSquares';
 
@@ -15,8 +15,8 @@ export default class PaletteSquares extends AL {
     initializeConstantProperties() {
         this.modes = ['hue', 'saturation', 'luminosity', 'alpha', 'random'];
         this.mode = AL.pickRandomElement(this.modes);
-        this.ctx.strokeStyle = 'black';
-        this.ctx.lineWidth = 4;
+        AL.ctx.strokeStyle = 'black';
+        AL.ctx.lineWidth = 4;
     }
 
     initializeProperties() {
@@ -25,22 +25,22 @@ export default class PaletteSquares extends AL {
         this.squares = Array.from({ length: this.colors.length }, (_, index) => ({
             color: this.colors[index],
             size: AL.random(10, 300),
-            x: AL.random(0, this.w),
-            y: AL.random(0, this.h),
+            x: AL.random(0, AL.w),
+            y: AL.random(0, AL.h),
         }));
     }
 
     draw() {
         if (this.t % this.speed === 0) {
             for (const square of this.squares) {
-                this.ctx.fillStyle = square.color;
-                this.ctx.fillRect(
+                AL.ctx.fillStyle = square.color;
+                AL.ctx.fillRect(
                     square.x - square.size / 2,
                     square.y - square.size / 2,
                     square.size,
                     square.size,
                 );
-                this.ctx.strokeRect(
+                AL.ctx.strokeRect(
                     square.x - square.size / 2,
                     square.y - square.size / 2,
                     square.size,

--- a/src/algos/ParallelUniverses.js
+++ b/src/algos/ParallelUniverses.js
@@ -2,8 +2,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class ParallelUniverses extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Parallel Universes';
 
@@ -14,26 +14,26 @@ export default class ParallelUniverses extends AL {
 
     initializeProperties() {
         this.rotate = AL.random(1, 11);
-        this.x1 = AL.random(0, this.w);
-        this.y1 = AL.random(0, this.h);
-        this.x2 = AL.random(0, this.w);
-        this.y2 = AL.random(0, this.h);
-        this.x3 = AL.random(0, this.w);
-        this.y3 = AL.random(0, this.h);
-        this.x4 = AL.random(0, this.w);
-        this.y4 = AL.random(0, this.h);
+        this.x1 = AL.random(0, AL.w);
+        this.y1 = AL.random(0, AL.h);
+        this.x2 = AL.random(0, AL.w);
+        this.y2 = AL.random(0, AL.h);
+        this.x3 = AL.random(0, AL.w);
+        this.y3 = AL.random(0, AL.h);
+        this.x4 = AL.random(0, AL.w);
+        this.y4 = AL.random(0, AL.h);
         this.rounded1 = AL.random(5, 250);
         this.rounded2 = AL.random(5, 250);
         this.rounded3 = AL.random(5, 250);
         this.rounded4 = AL.random(5, 250);
-        this.side1 = AL.random(20, this.w);
-        this.side2 = AL.random(20, this.h);
-        this.side3 = AL.random(20, this.w);
-        this.side4 = AL.random(20, this.h);
-        this.side5 = AL.random(20, this.w);
-        this.side6 = AL.random(20, this.h);
-        this.side7 = AL.random(20, this.w);
-        this.side8 = AL.random(20, this.h);
+        this.side1 = AL.random(20, AL.w);
+        this.side2 = AL.random(20, AL.h);
+        this.side3 = AL.random(20, AL.w);
+        this.side4 = AL.random(20, AL.h);
+        this.side5 = AL.random(20, AL.w);
+        this.side6 = AL.random(20, AL.h);
+        this.side7 = AL.random(20, AL.w);
+        this.side8 = AL.random(20, AL.h);
         this.color1 = AL.randomColor(0, 255, 0.05, 0.1);
         this.color2 = AL.randomColor(0, 255, 0.05, 0.1);
     }
@@ -43,8 +43,8 @@ export default class ParallelUniverses extends AL {
             this.stagger %= 4;
 
             if (this.stagger === 0) {
-                this.ctx.fillStyle = this.color1;
-                this.ctx.roundRectExtra(
+                AL.ctx.fillStyle = this.color1;
+                AL.ctx.roundRectExtra(
                     this.x1++,
                     this.y1++,
                     this.side1++,
@@ -61,8 +61,8 @@ export default class ParallelUniverses extends AL {
             }
 
             if (this.stagger === 1) {
-                this.ctx.fillStyle = this.color2;
-                this.ctx.roundRectExtra(
+                AL.ctx.fillStyle = this.color2;
+                AL.ctx.roundRectExtra(
                     this.x2--,
                     this.y2--,
                     this.side3--,
@@ -79,8 +79,8 @@ export default class ParallelUniverses extends AL {
             }
 
             if (this.stagger === 2) {
-                this.ctx.fillStyle = this.color1;
-                this.ctx.roundRectExtra(
+                AL.ctx.fillStyle = this.color1;
+                AL.ctx.roundRectExtra(
                     this.x3++,
                     this.y3++,
                     this.side5++,
@@ -97,8 +97,8 @@ export default class ParallelUniverses extends AL {
             }
 
             if (this.stagger === 3) {
-                this.ctx.fillStyle = this.color2;
-                this.ctx.roundRectExtra(
+                AL.ctx.fillStyle = this.color2;
+                AL.ctx.roundRectExtra(
                     this.x4,
                     this.y4,
                     this.side7,

--- a/src/algos/Patterns.js
+++ b/src/algos/Patterns.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Patterns extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Patterns';
 
@@ -14,26 +14,26 @@ export default class Patterns extends AL {
 
     initializeProperties() {
         this.radius = AL.random(10, 250);
-        this.rows = Math.ceil(this.h / 100) + 2;
-        this.cols = Math.ceil(this.w / 100) + 2;
+        this.rows = Math.ceil(AL.h / 100) + 2;
+        this.cols = Math.ceil(AL.w / 100) + 2;
     }
 
     setupDrawingStyles() {
-        this.ctx.lineWidth = 3;
-        this.ctx.globalAlpha = 0.1;
-        this.ctx.strokeStyle = 'white';
-        this.ctx.globalCompositeOperation = 'overlay';
-        this.ctx.fillStyle = AL.randomColor(0, 255, 0.05, 0.6);
+        AL.ctx.lineWidth = 3;
+        AL.ctx.globalAlpha = 0.1;
+        AL.ctx.strokeStyle = 'white';
+        AL.ctx.globalCompositeOperation = 'overlay';
+        AL.ctx.fillStyle = AL.randomColor(0, 255, 0.05, 0.6);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
             for (let i = 0; i <= this.rows; i++) {
                 for (let j = 0; j <= this.cols; j++) {
-                    this.ctx.beginPath();
-                    this.ctx.arc(100 * j - 50, 100 * i - 50, this.radius, 0, 2 * Math.PI);
-                    this.ctx.stroke();
-                    this.ctx.fill();
+                    AL.ctx.beginPath();
+                    AL.ctx.arc(100 * j - 50, 100 * i - 50, this.radius, 0, 2 * Math.PI);
+                    AL.ctx.stroke();
+                    AL.ctx.fill();
                 }
             }
         }
@@ -43,15 +43,15 @@ export default class Patterns extends AL {
         if (this.t % (this.speed * 40) === 0) {
             this.radius = AL.random(10, 250);
 
-            this.ctx.globalCompositeOperation = 'xor';
-            this.ctx.strokeStyle = 'black';
-            this.ctx.fillStyle = AL.randomColor(0, 255, 0.05, 0.6);
-            this.ctx.beginPath();
-            this.ctx.arc(this.w / 2, this.h / 2, this.radius * 3, 0, 2 * Math.PI);
-            this.ctx.stroke();
-            this.ctx.fill();
-            this.ctx.globalCompositeOperation = 'overlay';
-            this.ctx.strokeStyle = 'white';
+            AL.ctx.globalCompositeOperation = 'xor';
+            AL.ctx.strokeStyle = 'black';
+            AL.ctx.fillStyle = AL.randomColor(0, 255, 0.05, 0.6);
+            AL.ctx.beginPath();
+            AL.ctx.arc(AL.w / 2, AL.h / 2, this.radius * 3, 0, 2 * Math.PI);
+            AL.ctx.stroke();
+            AL.ctx.fill();
+            AL.ctx.globalCompositeOperation = 'overlay';
+            AL.ctx.strokeStyle = 'white';
         }
 
         this.requestFrame();

--- a/src/algos/Perspective.js
+++ b/src/algos/Perspective.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Perspective extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Perspective';
 
@@ -25,36 +25,36 @@ export default class Perspective extends AL {
     }
 
     setupDrawingStyles() {
-        this.ctx.fillStyle = this.color1;
+        AL.ctx.fillStyle = this.color1;
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.fillStyle = this.color1;
-            this.ctx.setTransform(2, this.skewX, this.skewY, 2, 0, 0);
-            this.ctx.fillRect(
-                Math.round(AL.random(-200, this.w) / this.size) * this.size,
-                Math.round(AL.random(-260, this.h) / this.size) * this.size,
+            AL.ctx.fillStyle = this.color1;
+            AL.ctx.setTransform(2, this.skewX, this.skewY, 2, 0, 0);
+            AL.ctx.fillRect(
+                Math.round(AL.random(-200, AL.w) / this.size) * this.size,
+                Math.round(AL.random(-260, AL.h) / this.size) * this.size,
                 this.size,
                 this.size,
             );
-            this.ctx.fill();
+            AL.ctx.fill();
 
-            this.ctx.fillStyle = this.color2;
-            this.ctx.fillRect(
-                Math.round(AL.random(-200, this.w) / this.size) * this.size,
-                Math.round(AL.random(-260, this.h) / this.size) * this.size,
+            AL.ctx.fillStyle = this.color2;
+            AL.ctx.fillRect(
+                Math.round(AL.random(-200, AL.w) / this.size) * this.size,
+                Math.round(AL.random(-260, AL.h) / this.size) * this.size,
                 this.size,
                 this.size,
             );
-            this.ctx.fill();
+            AL.ctx.fill();
         }
 
         this.t += 1;
 
         if (this.t % (this.speed * 2000) === 0) {
             this.initializeProperties();
-            this.ctx.clearRect(-200, -200, this.w, this.h);
+            AL.ctx.clearRect(-200, -200, AL.w, AL.h);
         }
 
         this.requestFrame();

--- a/src/algos/Picnic.js
+++ b/src/algos/Picnic.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Picnic extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Picnic';
 
@@ -15,8 +15,8 @@ export default class Picnic extends AL {
     }
 
     initializeBaseProperties() {
-        this.rows = Math.ceil(this.h / 150) + 2;
-        this.cols = Math.ceil(this.w / 150) + 2;
+        this.rows = Math.ceil(AL.h / 150) + 2;
+        this.cols = Math.ceil(AL.w / 150) + 2;
     }
 
     initializeProperties() {
@@ -24,21 +24,21 @@ export default class Picnic extends AL {
     }
 
     setupConstantStyles() {
-        this.ctx.globalCompositeOperation = 'source-over';
+        AL.ctx.globalCompositeOperation = 'source-over';
     }
 
     setupDrawingStyles() {
-        this.ctx.lineWidth = AL.random(1, 25);
-        this.ctx.strokeStyle = AL.randomColor(10, 255, 0.2, 0.5);
+        AL.ctx.lineWidth = AL.random(1, 25);
+        AL.ctx.strokeStyle = AL.randomColor(10, 255, 0.2, 0.5);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
             for (let i = 0; i <= this.rows; i++) {
                 for (let j = 0; j <= this.cols; j++) {
-                    this.ctx.beginPath();
-                    this.ctx.arc(225 * j - 225, 225 * i - 225, this.radius, 0, 2 * Math.PI);
-                    this.ctx.stroke();
+                    AL.ctx.beginPath();
+                    AL.ctx.arc(225 * j - 225, 225 * i - 225, this.radius, 0, 2 * Math.PI);
+                    AL.ctx.stroke();
                 }
             }
         }
@@ -48,23 +48,23 @@ export default class Picnic extends AL {
         if (this.t % (this.speed * 30) === 0) {
             this.initializeProperties();
             this.setupDrawingStyles();
-            this.ctx.globalCompositeOperation = 'source-over';
+            AL.ctx.globalCompositeOperation = 'source-over';
         }
 
         if (this.t * (this.speed * 90) === 0) {
-            this.ctx.globalCompositeOperation = 'overlay';
+            AL.ctx.globalCompositeOperation = 'overlay';
         }
 
         if (this.t % (this.speed * 150) === 0) {
-            this.ctx.globalCompositeOperation = 'color';
+            AL.ctx.globalCompositeOperation = 'color';
         }
 
         if (this.t % (this.speed * 240) === 0) {
-            this.ctx.globalCompositeOperation = 'luminosity';
+            AL.ctx.globalCompositeOperation = 'luminosity';
         }
 
         if (this.t % (this.speed * 570) === 0) {
-            this.ctx.globalCompositeOperation = 'hue';
+            AL.ctx.globalCompositeOperation = 'hue';
         }
 
         this.requestFrame();

--- a/src/algos/PietriDish.js
+++ b/src/algos/PietriDish.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class PietriDish extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Pietri Dish';
 
@@ -21,37 +21,37 @@ export default class PietriDish extends AL {
     }
 
     setupConstantStyles() {
-        this.ctx.shadowBlur = 35;
-        this.ctx.globalCompositeOperation = 'overlay';
-        this.ctx.shadowColor = AL.randomColor(100, 255, 0.75, 1);
+        AL.ctx.shadowBlur = 35;
+        AL.ctx.globalCompositeOperation = 'overlay';
+        AL.ctx.shadowColor = AL.randomColor(100, 255, 0.75, 1);
     }
 
     setupDrawingStyles() {
-        this.ctx.fillStyle = AL.randomColor();
-        this.ctx.lineWidth = AL.random(2, 18);
-        this.ctx.strokeStyle = AL.randomColor();
-        this.ctx.shadowColor = AL.randomColor(100, 255, 0.75, 1);
+        AL.ctx.fillStyle = AL.randomColor();
+        AL.ctx.lineWidth = AL.random(2, 18);
+        AL.ctx.strokeStyle = AL.randomColor();
+        AL.ctx.shadowColor = AL.randomColor(100, 255, 0.75, 1);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.beginPath();
-            this.ctx.arc(
+            AL.ctx.beginPath();
+            AL.ctx.arc(
                 this.x - this.size / 2,
                 this.y - this.size / 2,
                 this.size / 2,
                 0,
                 2 * Math.PI,
             );
-            this.ctx.stroke();
-            this.ctx.fill();
+            AL.ctx.stroke();
+            AL.ctx.fill();
 
             this.x += this.size;
-            if (this.x > this.w) {
+            if (this.x > AL.w) {
                 this.x = 0;
                 this.y += this.size;
             }
-            if (this.y > this.h) {
+            if (this.y > AL.h) {
                 this.x = 0;
                 this.y = 0;
                 this.size = AL.random(15, 115);
@@ -63,16 +63,16 @@ export default class PietriDish extends AL {
         if (this.t % (this.speed * 150) === 0) {
             this.rotate = AL.random(1, 90);
 
-            this.ctx.fillStyle = Math.random() < 0.2 ? 'black' : AL.randomColor();
+            AL.ctx.fillStyle = Math.random() < 0.2 ? 'black' : AL.randomColor();
 
-            this.ctx.lineWidth = AL.random(2, 18);
-            this.ctx.shadowColor = AL.randomColor(100, 255, 0.75, 1);
+            AL.ctx.lineWidth = AL.random(2, 18);
+            AL.ctx.shadowColor = AL.randomColor(100, 255, 0.75, 1);
         }
 
         if (this.t % (this.speed * 450) === 0) {
-            this.ctx.beginPath();
+            AL.ctx.beginPath();
             this.size = AL.random(15, 85);
-            this.ctx.strokeStyle = AL.randomColor();
+            AL.ctx.strokeStyle = AL.randomColor();
         }
 
         this.rotateCanvasDegrees(this.rotate);

--- a/src/algos/Plaid.js
+++ b/src/algos/Plaid.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Plaid extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Plaid';
 
@@ -14,8 +14,8 @@ export default class Plaid extends AL {
     }
 
     initializeBaseProperties() {
-        this.rows = Math.ceil(this.h / 100) + 2;
-        this.cols = Math.ceil(this.w / 100) + 2;
+        this.rows = Math.ceil(AL.h / 100) + 2;
+        this.cols = Math.ceil(AL.w / 100) + 2;
     }
 
     initializeProperties() {
@@ -24,11 +24,11 @@ export default class Plaid extends AL {
     }
 
     setupDrawingStyles() {
-        this.ctx.globalAlpha = 0.3;
-        this.ctx.lineWidth = AL.random(1, 13);
-        this.ctx.globalCompositeOperation = 'source-over';
-        this.ctx.fillStyle = AL.randomColor(10, 255, 0.2, 0.7);
-        this.ctx.strokeStyle = AL.randomColor(10, 255, 0.2, 0.7);
+        AL.ctx.globalAlpha = 0.3;
+        AL.ctx.lineWidth = AL.random(1, 13);
+        AL.ctx.globalCompositeOperation = 'source-over';
+        AL.ctx.fillStyle = AL.randomColor(10, 255, 0.2, 0.7);
+        AL.ctx.strokeStyle = AL.randomColor(10, 255, 0.2, 0.7);
     }
 
     draw() {
@@ -37,9 +37,9 @@ export default class Plaid extends AL {
                 this.rotateCanvasDegrees(45);
 
                 for (let j = 0; j <= this.cols; j++) {
-                    this.ctx.beginPath();
-                    this.ctx.strokeRect(150 * j - 150, 150 * i - 150, this.side1, this.side2);
-                    this.ctx.fillRect(150 * j - 150, 150 * i - 150, this.side1, this.side2);
+                    AL.ctx.beginPath();
+                    AL.ctx.strokeRect(150 * j - 150, 150 * i - 150, this.side1, this.side2);
+                    AL.ctx.fillRect(150 * j - 150, 150 * i - 150, this.side1, this.side2);
                 }
             }
         }
@@ -48,29 +48,29 @@ export default class Plaid extends AL {
 
         if (this.t % (this.speed * 30) === 0) {
             this.initializeProperties();
-            this.ctx.lineWidth = AL.random(1, 13);
-            this.ctx.globalCompositeOperation = 'overlay';
-            this.ctx.fillStyle = AL.randomColor(10, 255, 0.2, 0.7);
+            AL.ctx.lineWidth = AL.random(1, 13);
+            AL.ctx.globalCompositeOperation = 'overlay';
+            AL.ctx.fillStyle = AL.randomColor(10, 255, 0.2, 0.7);
         }
 
         if (this.t % (this.speed * 60) === 0) {
-            this.ctx.strokeStyle = AL.randomColor(10, 255, 0.2, 0.7);
+            AL.ctx.strokeStyle = AL.randomColor(10, 255, 0.2, 0.7);
         }
 
         if (this.t % (this.speed * 90) === 0) {
-            this.ctx.globalCompositeOperation = 'source-over';
+            AL.ctx.globalCompositeOperation = 'source-over';
         }
 
         if (this.t % (this.speed * 150) === 0) {
-            this.ctx.globalCompositeOperation = 'color';
+            AL.ctx.globalCompositeOperation = 'color';
         }
 
         if (this.t % (this.speed * 240) === 0) {
-            this.ctx.globalCompositeOperation = 'luminosity';
+            AL.ctx.globalCompositeOperation = 'luminosity';
         }
 
         if (this.t % (this.speed * 570) === 0) {
-            this.ctx.globalCompositeOperation = 'hue';
+            AL.ctx.globalCompositeOperation = 'hue';
         }
 
         this.requestFrame();

--- a/src/algos/Polyhedra.js
+++ b/src/algos/Polyhedra.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Polyhedra extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Polyhedra';
 
@@ -20,19 +20,19 @@ export default class Polyhedra extends AL {
     }
 
     initializeProperties() {
-        this.x = AL.random(0, this.w);
-        this.y = AL.random(0, this.h);
+        this.x = AL.random(0, AL.w);
+        this.y = AL.random(0, AL.h);
         this.rotate = AL.pickRandomElement(this.rotations);
     }
 
     setupDrawingStyles() {
-        this.ctx.fillStyle = AL.randomColor(0, 255, 0.01, 0.05);
+        AL.ctx.fillStyle = AL.randomColor(0, 255, 0.01, 0.05);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.lineTo(this.x, this.y);
-            this.ctx.fill();
+            AL.ctx.lineTo(this.x, this.y);
+            AL.ctx.fill();
 
             this.rotateCanvasRadians(this.rotate);
         }
@@ -42,7 +42,7 @@ export default class Polyhedra extends AL {
         if (this.t % (this.speed * 60) === 0) {
             this.initializeProperties();
             this.setupDrawingStyles();
-            this.ctx.beginPath();
+            AL.ctx.beginPath();
         }
 
         this.requestFrame();

--- a/src/algos/Portals.js
+++ b/src/algos/Portals.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Portals extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Portals';
 
@@ -14,8 +14,8 @@ export default class Portals extends AL {
     }
 
     initializeProperties() {
-        this.height = AL.random(20, this.h / this.rows + 3);
-        this.width = AL.random(20, this.w / this.cols + 3);
+        this.height = AL.random(20, AL.h / this.rows + 3);
+        this.width = AL.random(20, AL.w / this.cols + 3);
         this.rotate = AL.random(1, 33);
         this.round = AL.random(0, 60);
         this.cols = AL.random(3, 13);
@@ -23,22 +23,22 @@ export default class Portals extends AL {
     }
 
     setupConstantStyles() {
-        this.ctx.globalCompositeOperation = 'hard-light';
-        this.ctx.globalAlpha = 0.6;
+        AL.ctx.globalCompositeOperation = 'hard-light';
+        AL.ctx.globalAlpha = 0.6;
     }
 
     setupDrawingStyles() {
-        this.ctx.fillStyle = AL.randomColor(0, 255, 0.45, 0.45);
-        this.ctx.strokeStyle = AL.randomColor(0, 255, 1, 1);
+        AL.ctx.fillStyle = AL.randomColor(0, 255, 0.45, 0.45);
+        AL.ctx.strokeStyle = AL.randomColor(0, 255, 1, 1);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
             for (let row = 0; row <= this.rows; row++) {
                 for (let col = 0; col <= this.cols; col++) {
-                    this.ctx.roundRectExtra(
-                        col * (this.w / this.cols),
-                        row * (this.h / this.rows),
+                    AL.ctx.roundRectExtra(
+                        col * (AL.w / this.cols),
+                        row * (AL.h / this.rows),
                         this.width,
                         this.height,
                         {

--- a/src/algos/Progression.js
+++ b/src/algos/Progression.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Progression extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Progression';
 
@@ -13,21 +13,21 @@ export default class Progression extends AL {
     }
 
     initializeProperties() {
-        this.height = AL.random(40, this.h);
-        this.width = AL.random(40, this.w);
+        this.height = AL.random(40, AL.h);
+        this.width = AL.random(40, AL.w);
         this.rotate = AL.random(1, 180);
         this.round = AL.random(1, 350);
     }
 
     setupDrawingStyles() {
-        this.ctx.fillStyle = AL.randomColor(0, 255, 0.01, 0.03);
+        AL.ctx.fillStyle = AL.randomColor(0, 255, 0.01, 0.03);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.roundRectExtra(
-                this.w / 2,
-                this.h / 2,
+            AL.ctx.roundRectExtra(
+                AL.w / 2,
+                AL.h / 2,
                 this.width,
                 this.height,
                 {
@@ -48,7 +48,7 @@ export default class Progression extends AL {
         if (this.t % (this.speed * 180) === 0) {
             this.initializeProperties();
             this.setupDrawingStyles();
-            this.ctx.beginPath();
+            AL.ctx.beginPath();
         }
 
         this.requestFrame();

--- a/src/algos/Projecting.js
+++ b/src/algos/Projecting.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Projecting extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Projecting';
 
@@ -53,21 +53,21 @@ export default class Projecting extends AL {
     }
 
     setupConstantStyles() {
-        this.ctx.shadowBlur = 10;
-        this.ctx.strokeStyle = 'black';
-        this.ctx.shadowColor = this.color3.color;
+        AL.ctx.shadowBlur = 10;
+        AL.ctx.strokeStyle = 'black';
+        AL.ctx.shadowColor = this.color3.color;
     }
 
     setupDrawingStyles() {
-        this.ctx.fillStyle = this.color1.color;
-        this.ctx.globalCompositeOperation = AL.pickRandomElement(this.modes);
+        AL.ctx.fillStyle = this.color1.color;
+        AL.ctx.globalCompositeOperation = AL.pickRandomElement(this.modes);
     }
 
     draw() {
-        this.ctx.translate(this.w / 2, this.h / 2);
-        this.ctx.rotate(this.rotate1.rot * (Math.PI / 180));
-        this.ctx.fillRect(0, 0, this.w, this.width);
-        this.ctx.translate(-this.w / 2, -this.h / 2);
+        AL.ctx.translate(AL.w / 2, AL.h / 2);
+        AL.ctx.rotate(this.rotate1.rot * (Math.PI / 180));
+        AL.ctx.fillRect(0, 0, AL.w, this.width);
+        AL.ctx.translate(-AL.w / 2, -AL.h / 2);
 
         this.t += 1;
 
@@ -105,7 +105,7 @@ export default class Projecting extends AL {
             {
                 color: this.color2.color,
                 duration: AL.random(3, 10),
-                onUpdate: () => (this.ctx.fillStyle = this.color1.color),
+                onUpdate: () => (AL.ctx.fillStyle = this.color1.color),
             },
             '<',
         );
@@ -114,7 +114,7 @@ export default class Projecting extends AL {
             {
                 color: this.color4.color,
                 duration: AL.random(3, 10),
-                onUpdate: () => (this.ctx.shadowColor = this.color3.color),
+                onUpdate: () => (AL.ctx.shadowColor = this.color3.color),
             },
             '<',
         );

--- a/src/algos/PsychoRainbow.js
+++ b/src/algos/PsychoRainbow.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class PsychoRainbow extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Psycho Rainbow';
 
@@ -21,20 +21,20 @@ export default class PsychoRainbow extends AL {
     initializeProperties() {
         this.rows = AL.random(3, 10);
         this.rotate = AL.random(1, 50);
-        this.height = this.h / this.rows;
+        this.height = AL.h / this.rows;
 
         this.colors = AL.generateRGBAPalette(this.rows, 0, 255, 0.1, 0.5);
     }
 
     setupDrawingStyles() {
-        this.ctx.globalCompositeOperation = this.blend;
+        AL.ctx.globalCompositeOperation = this.blend;
     }
 
     draw() {
         if (this.t % this.speed === 0) {
             for (let i = 0; i <= this.rows; i++) {
-                this.ctx.fillStyle = this.colors[i];
-                this.ctx.fillRect(-this.w, i * this.height, 3 * this.w, this.height);
+                AL.ctx.fillStyle = this.colors[i];
+                AL.ctx.fillRect(-AL.w, i * this.height, 3 * AL.w, this.height);
             }
         }
 

--- a/src/algos/Pulsar.js
+++ b/src/algos/Pulsar.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Pulsar extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Pulsar';
 
@@ -14,25 +14,25 @@ export default class Pulsar extends AL {
     }
 
     initializeProperties() {
-        this.x = AL.random(0, this.w);
-        this.y = AL.random(0, this.h);
+        this.x = AL.random(0, AL.w);
+        this.y = AL.random(0, AL.h);
         this.rotate1 = AL.random(1, 90);
         this.rotate2 = AL.random(1, 90);
         this.pulse1 = AL.random(50, 300);
         this.pulse2 = AL.random(30, 200);
-        this.cp1x = AL.random(0, this.w);
-        this.cp1y = AL.random(0, this.h);
-        this.cp2x = AL.random(0, this.w);
-        this.cp2y = AL.random(0, this.h);
+        this.cp1x = AL.random(0, AL.w);
+        this.cp1y = AL.random(0, AL.h);
+        this.cp2x = AL.random(0, AL.w);
+        this.cp2y = AL.random(0, AL.h);
     }
 
     setupConstantProperties() {
-        this.ctx.lineWidth = 5;
-        this.ctx.shadowBlur = 2;
+        AL.ctx.lineWidth = 5;
+        AL.ctx.shadowBlur = 2;
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = this.ctx.shadowColor = AL.randomColor();
+        AL.ctx.strokeStyle = AL.ctx.shadowColor = AL.randomColor();
     }
 
     draw() {
@@ -58,15 +58,15 @@ export default class Pulsar extends AL {
     }
 
     drawBezier(rot) {
-        this.ctx.save();
-        this.ctx.beginPath();
-        this.ctx.moveTo(
-            this.w / 2 + Math.sin(this.t) * this.pulse1,
-            this.h / 2 + Math.cos(this.t) * this.pulse2,
+        AL.ctx.save();
+        AL.ctx.beginPath();
+        AL.ctx.moveTo(
+            AL.w / 2 + Math.sin(this.t) * this.pulse1,
+            AL.h / 2 + Math.cos(this.t) * this.pulse2,
         );
-        this.ctx.translate(this.w / 2, this.h / 2);
-        this.ctx.rotate((rot * Math.PI) / 180);
-        this.ctx.bezierCurveTo(
+        AL.ctx.translate(AL.w / 2, AL.h / 2);
+        AL.ctx.rotate((rot * Math.PI) / 180);
+        AL.ctx.bezierCurveTo(
             this.cp1x + rot,
             this.cp1y + this.pulse1,
             this.cp2x - rot,
@@ -74,9 +74,9 @@ export default class Pulsar extends AL {
             this.x,
             this.y,
         );
-        this.ctx.stroke();
-        this.ctx.closePath();
-        this.ctx.translate(-this.w / 2, -this.h / 2);
-        this.ctx.restore();
+        AL.ctx.stroke();
+        AL.ctx.closePath();
+        AL.ctx.translate(-AL.w / 2, -AL.h / 2);
+        AL.ctx.restore();
     }
 }

--- a/src/algos/Punctuation.js
+++ b/src/algos/Punctuation.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Punctuation extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Punctuation';
 
@@ -41,8 +41,8 @@ export default class Punctuation extends AL {
 
     setupDrawingStyles() {
         this.fontChange = AL.random(35, 250);
-        this.ctx.font = `${this.fontChange}px sans-serif`;
-        this.ctx.fillStyle = AL.randomColor(0, 255, 0.66, 0.66);
+        AL.ctx.font = `${this.fontChange}px sans-serif`;
+        AL.ctx.fillStyle = AL.randomColor(0, 255, 0.66, 0.66);
     }
 
     draw() {
@@ -52,21 +52,21 @@ export default class Punctuation extends AL {
             if (this.stagger === 0) {
                 this.rotateCanvasDegrees(this.rotate);
 
-                this.ctx.fillText(this.letter, this.w / 2, this.h / 2);
+                AL.ctx.fillText(this.letter, AL.w / 2, AL.h / 2);
             }
 
             if (this.stagger === 1) {
-                this.ctx.fillText(`  ${this.letter}`, this.w / 2, this.h / 2);
+                AL.ctx.fillText(`  ${this.letter}`, AL.w / 2, AL.h / 2);
 
                 this.rotateCanvasDegrees(this.rotate);
             }
 
             if (this.stagger === 2) {
-                this.ctx.fillText(`    ${this.letter}`, this.w / 2, this.h / 2);
+                AL.ctx.fillText(`    ${this.letter}`, AL.w / 2, AL.h / 2);
             }
 
             if (this.stagger === 3) {
-                this.ctx.fillText(`      ${this.letter}`, this.w / 2, this.h / 2);
+                AL.ctx.fillText(`      ${this.letter}`, AL.w / 2, AL.h / 2);
             }
 
             this.stagger += 1;
@@ -77,11 +77,11 @@ export default class Punctuation extends AL {
         if (this.t % (this.speed * 100) === 0) {
             this.rotate = AL.random(-35, -10);
             this.fontChange = AL.random(35, 250);
-            this.ctx.font = `${this.fontChange}px sans-serif`;
+            AL.ctx.font = `${this.fontChange}px sans-serif`;
         }
 
         if (this.t % (this.speed * 200) === 0) {
-            this.ctx.fillStyle = AL.randomColor(0, 255, 0.66, 0.66);
+            AL.ctx.fillStyle = AL.randomColor(0, 255, 0.66, 0.66);
         }
 
         if (this.t % (this.speed * 400) === 0) {

--- a/src/algos/Quadrants.js
+++ b/src/algos/Quadrants.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Quadrants extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Quadrants';
 
@@ -17,7 +17,7 @@ export default class Quadrants extends AL {
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = this.ctx.fillStyle = AL.randomColor(0, 255, 0.3, 0.3);
+        AL.ctx.strokeStyle = AL.ctx.fillStyle = AL.randomColor(0, 255, 0.3, 0.3);
     }
 
     draw() {
@@ -25,33 +25,33 @@ export default class Quadrants extends AL {
             this.stagger %= 5;
 
             if (this.stagger === 0) {
-                this.ctx.arc(this.w / 4, this.h / 4, this.radius, 0, 360);
-                this.ctx.stroke();
-                this.ctx.beginPath();
+                AL.ctx.arc(AL.w / 4, AL.h / 4, this.radius, 0, 360);
+                AL.ctx.stroke();
+                AL.ctx.beginPath();
             }
 
             if (this.stagger === 1) {
-                this.ctx.arc(this.w * 0.75, this.h / 4, this.radius, 0, 360);
-                this.ctx.stroke();
-                this.ctx.beginPath();
+                AL.ctx.arc(AL.w * 0.75, AL.h / 4, this.radius, 0, 360);
+                AL.ctx.stroke();
+                AL.ctx.beginPath();
             }
 
             if (this.stagger === 2) {
-                this.ctx.arc(this.w / 4, this.h * 0.75, this.radius, 0, 360);
-                this.ctx.stroke();
-                this.ctx.beginPath();
+                AL.ctx.arc(AL.w / 4, AL.h * 0.75, this.radius, 0, 360);
+                AL.ctx.stroke();
+                AL.ctx.beginPath();
             }
 
             if (this.stagger === 3) {
-                this.ctx.arc(this.w * 0.75, this.h * 0.75, this.radius, 0, 360);
-                this.ctx.stroke();
-                this.ctx.beginPath();
+                AL.ctx.arc(AL.w * 0.75, AL.h * 0.75, this.radius, 0, 360);
+                AL.ctx.stroke();
+                AL.ctx.beginPath();
             }
 
             if (this.stagger === 4) {
-                this.ctx.arc(this.w / 2, this.h / 2, this.radius, 0, 360);
-                this.ctx.stroke();
-                this.ctx.beginPath();
+                AL.ctx.arc(AL.w / 2, AL.h / 2, this.radius, 0, 360);
+                AL.ctx.stroke();
+                AL.ctx.beginPath();
             }
 
             this.stagger += 1;
@@ -68,8 +68,8 @@ export default class Quadrants extends AL {
         }
 
         if (this.t % (this.speed * 225) === 0) {
-            this.ctx.lineWidth = AL.random(1, 40);
-            this.ctx.strokeStyle = this.ctx.fillStyle = 'black';
+            AL.ctx.lineWidth = AL.random(1, 40);
+            AL.ctx.strokeStyle = AL.ctx.fillStyle = 'black';
         }
 
         this.requestFrame();

--- a/src/algos/Quadratic.js
+++ b/src/algos/Quadratic.js
@@ -2,8 +2,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Quadratic extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Quadratic';
 
@@ -26,13 +26,13 @@ export default class Quadratic extends AL {
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = AL.randomColor(0, 255, 0.5, 1);
+        AL.ctx.strokeStyle = AL.randomColor(0, 255, 0.5, 1);
     }
 
     createQuadraticSequence(startNum, firstDiff, secondDiff) {
         const arr = [startNum];
 
-        while (startNum < Math.max(this.w, this.h)) {
+        while (startNum < Math.max(AL.w, AL.h)) {
             startNum += firstDiff;
             firstDiff += secondDiff;
             arr.push(startNum);
@@ -44,7 +44,7 @@ export default class Quadratic extends AL {
     draw() {
         if (this.t % this.speed === 0) {
             for (const num of this.nums) {
-                this.ctx.strokeRect(this.w / 2 - num / 2, this.h / 2 - num / 2, num, num);
+                AL.ctx.strokeRect(AL.w / 2 - num / 2, AL.h / 2 - num / 2, num, num);
             }
         }
 
@@ -55,7 +55,7 @@ export default class Quadratic extends AL {
         if (this.t % (this.speed * 90) === 0) {
             this.initializeProperties();
             this.setupDrawingStyles();
-            this.ctx.beginPath();
+            AL.ctx.beginPath();
         }
 
         if (this.t % (this.speed * 180) === 0) {

--- a/src/algos/Radiance.js
+++ b/src/algos/Radiance.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Radiance extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Radiance';
 
@@ -26,26 +26,26 @@ export default class Radiance extends AL {
         this.rounded2 = AL.random(15, 50);
         this.rounded3 = AL.random(15, 50);
         this.rounded4 = AL.random(15, 50);
-        this.x1 = AL.random(0, this.w / 2);
-        this.y1 = AL.random(0, this.h / 2);
-        this.y2 = AL.random(0, this.h / 2);
-        this.x4 = AL.random(0, this.w / 2);
-        this.side1 = AL.random(60, this.w / 2);
-        this.side2 = AL.random(60, this.h / 2);
-        this.side3 = AL.random(60, this.w / 2);
-        this.side4 = AL.random(60, this.h / 2);
-        this.side5 = AL.random(60, this.w / 2);
-        this.side6 = AL.random(60, this.h / 2);
-        this.side7 = AL.random(60, this.w / 2);
-        this.side8 = AL.random(60, this.h / 2);
-        this.x2 = AL.random(this.w / 2, this.w);
-        this.x3 = AL.random(this.w / 2, this.w);
-        this.y3 = AL.random(this.h / 2, this.h);
-        this.y4 = AL.random(this.h / 2, this.h);
+        this.x1 = AL.random(0, AL.w / 2);
+        this.y1 = AL.random(0, AL.h / 2);
+        this.y2 = AL.random(0, AL.h / 2);
+        this.x4 = AL.random(0, AL.w / 2);
+        this.side1 = AL.random(60, AL.w / 2);
+        this.side2 = AL.random(60, AL.h / 2);
+        this.side3 = AL.random(60, AL.w / 2);
+        this.side4 = AL.random(60, AL.h / 2);
+        this.side5 = AL.random(60, AL.w / 2);
+        this.side6 = AL.random(60, AL.h / 2);
+        this.side7 = AL.random(60, AL.w / 2);
+        this.side8 = AL.random(60, AL.h / 2);
+        this.x2 = AL.random(AL.w / 2, AL.w);
+        this.x3 = AL.random(AL.w / 2, AL.w);
+        this.y3 = AL.random(AL.h / 2, AL.h);
+        this.y4 = AL.random(AL.h / 2, AL.h);
     }
 
     setupDrawingStyles() {
-        this.ctx.fillStyle = AL.randomColor(0, 255, 0.01, 0.05);
+        AL.ctx.fillStyle = AL.randomColor(0, 255, 0.01, 0.05);
     }
 
     draw() {
@@ -53,8 +53,8 @@ export default class Radiance extends AL {
             this.stagger %= 4;
 
             if (this.stagger === 0) {
-                this.ctx.strokeStyle = this.color1;
-                this.ctx.roundRectExtra(
+                AL.ctx.strokeStyle = this.color1;
+                AL.ctx.roundRectExtra(
                     this.x1,
                     this.y1,
                     this.side1,
@@ -71,8 +71,8 @@ export default class Radiance extends AL {
             }
 
             if (this.stagger === 1) {
-                this.ctx.strokeStyle = this.color2;
-                this.ctx.roundRectExtra(
+                AL.ctx.strokeStyle = this.color2;
+                AL.ctx.roundRectExtra(
                     this.x2,
                     this.y2,
                     this.side3,
@@ -89,8 +89,8 @@ export default class Radiance extends AL {
             }
 
             if (this.stagger === 2) {
-                this.ctx.strokeStyle = this.color3;
-                this.ctx.roundRectExtra(
+                AL.ctx.strokeStyle = this.color3;
+                AL.ctx.roundRectExtra(
                     this.x3,
                     this.y3,
                     this.side5,
@@ -107,8 +107,8 @@ export default class Radiance extends AL {
             }
 
             if (this.stagger === 3) {
-                this.ctx.strokeStyle = this.color4;
-                this.ctx.roundRectExtra(
+                AL.ctx.strokeStyle = this.color4;
+                AL.ctx.roundRectExtra(
                     this.x4,
                     this.y4,
                     this.side7,

--- a/src/algos/RadioWaves.js
+++ b/src/algos/RadioWaves.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class RadioWaves extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Radio Waves';
 
@@ -28,13 +28,13 @@ export default class RadioWaves extends AL {
     }
 
     setupConstantStyles() {
-        this.ctx.globalCompositeOperation = 'copy';
-        this.ctx.shadowBlur = 7;
-        this.ctx.lineWidth = 1;
+        AL.ctx.globalCompositeOperation = 'copy';
+        AL.ctx.shadowBlur = 7;
+        AL.ctx.lineWidth = 1;
     }
 
     setupDrawingStyles() {
-        this.ctx.shadowColor = this.ctx.strokeStyle = AL.randomColor(30, 255, 1, 1);
+        AL.ctx.shadowColor = AL.ctx.strokeStyle = AL.randomColor(30, 255, 1, 1);
     }
 
     draw() {
@@ -43,7 +43,7 @@ export default class RadioWaves extends AL {
             this.seq.push(radius);
             this.seq.shift();
 
-            if (radius > Math.max(this.w, this.h)) {
+            if (radius > Math.max(AL.w, AL.h)) {
                 this.first += 1;
                 this.second += 1;
                 this.seq = [this.first, this.second];
@@ -51,8 +51,8 @@ export default class RadioWaves extends AL {
                 this.rotateCanvasRadians(Math.PI / this.divisor);
             }
 
-            this.ctx.arc(this.w / this.posX, this.h / this.posY, radius, 0, 2 * Math.PI);
-            this.ctx.stroke();
+            AL.ctx.arc(AL.w / this.posX, AL.h / this.posY, radius, 0, 2 * Math.PI);
+            AL.ctx.stroke();
         }
 
         this.t += 1;
@@ -60,7 +60,7 @@ export default class RadioWaves extends AL {
         if (this.t % (this.speed * 360) === 0) {
             this.initializeProperties();
             this.setupDrawingStyles();
-            this.ctx.beginPath();
+            AL.ctx.beginPath();
         }
 
         if (this.t % (this.speed * 1440) === 0) {

--- a/src/algos/Records.js
+++ b/src/algos/Records.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Records extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Records';
 
@@ -18,22 +18,22 @@ export default class Records extends AL {
         this.rotate = AL.random(1, 45);
         this.offset = AL.random(50, 330);
         this.angleChange = Math.random() * 7;
-        this.radius = AL.random(50, Math.min(this.w, this.h) / 2);
+        this.radius = AL.random(50, Math.min(AL.w, AL.h) / 2);
     }
 
     setupConstantStyles() {
-        this.ctx.lineWidth = 2;
+        AL.ctx.lineWidth = 2;
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = this.ctx.fillStyle = AL.randomColor();
+        AL.ctx.strokeStyle = AL.ctx.fillStyle = AL.randomColor();
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.beginPath();
-            this.ctx.arc(this.w / 2, this.h / 2, this.radius, 0, Math.random() * Math.PI);
-            this.ctx.stroke();
+            AL.ctx.beginPath();
+            AL.ctx.arc(AL.w / 2, AL.h / 2, this.radius, 0, Math.random() * Math.PI);
+            AL.ctx.stroke();
 
             this.angle += this.angleChange;
             this.radius = Math.abs(this.radius + Math.sin(this.angle) * this.offset);
@@ -46,9 +46,9 @@ export default class Records extends AL {
         if (this.t % (this.speed * 120) === 0) {
             this.initializeProperties();
 
-            this.ctx.beginPath();
-            this.ctx.arc(this.w / 2, this.h / 2, this.radius, 0, 2 * Math.PI);
-            this.ctx.fill();
+            AL.ctx.beginPath();
+            AL.ctx.arc(AL.w / 2, AL.h / 2, this.radius, 0, 2 * Math.PI);
+            AL.ctx.fill();
 
             this.setupDrawingStyles();
         }

--- a/src/algos/Rims.js
+++ b/src/algos/Rims.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Rims extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Rims';
 
@@ -18,16 +18,16 @@ export default class Rims extends AL {
         this.rotate = AL.random(1, 6);
         this.startAngle = AL.random(0, 100);
         this.endAngle = AL.random(101, 360);
-        this.radius = AL.random(30, this.h);
+        this.radius = AL.random(30, AL.h);
         this.radius2 = AL.random(10, this.radius);
     }
 
     setupConstantStyles() {
-        this.ctx.strokeStyle = ' black';
+        AL.ctx.strokeStyle = ' black';
     }
 
     setupDrawingStyles() {
-        this.ctx.fillStyle = AL.randomColor(5, 255, 0.01, 0.01);
+        AL.ctx.fillStyle = AL.randomColor(5, 255, 0.01, 0.01);
     }
 
     draw() {
@@ -35,9 +35,9 @@ export default class Rims extends AL {
             this.stagger %= 3;
 
             if (this.stagger === 0) {
-                this.ctx.ellipse(
-                    this.w / 2,
-                    this.h / 2,
+                AL.ctx.ellipse(
+                    AL.w / 2,
+                    AL.h / 2,
                     this.radius,
                     this.radius2,
                     this.rotate,
@@ -47,9 +47,9 @@ export default class Rims extends AL {
             }
 
             if (this.stagger === 1) {
-                this.ctx.ellipse(
-                    this.w / 2,
-                    this.h / 2,
+                AL.ctx.ellipse(
+                    AL.w / 2,
+                    AL.h / 2,
                     this.radius2,
                     this.radius,
                     this.rotate,
@@ -59,20 +59,20 @@ export default class Rims extends AL {
             }
 
             if (this.stagger === 2) {
-                this.ctx.ellipse(
+                AL.ctx.ellipse(
                     this.startAngle + this.gap,
                     this.endAngle + this.gap,
                     this.radius,
                     this.radius2,
                     -this.rotate,
-                    this.w / 2,
-                    this.h / 2,
+                    AL.w / 2,
+                    AL.h / 2,
                 );
             }
         }
 
-        this.ctx.fill();
-        this.ctx.stroke();
+        AL.ctx.fill();
+        AL.ctx.stroke();
 
         this.t += 1;
 
@@ -82,7 +82,7 @@ export default class Rims extends AL {
             this.speed = AL.random(1, 10);
             this.initializeProperties();
             this.setupDrawingStyles();
-            this.ctx.beginPath();
+            AL.ctx.beginPath();
         }
 
         this.requestFrame();

--- a/src/algos/RotationPatterns.js
+++ b/src/algos/RotationPatterns.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class RotationPatterns extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Rotation Patterns';
 
@@ -20,15 +20,15 @@ export default class RotationPatterns extends AL {
     initializeProperties() {
         this.radiusX = AL.random(10, 250);
         this.radiusY = AL.random(10, 250);
-        this.rows = Math.ceil(this.h / this.radiusY) + 5;
-        this.cols = Math.ceil(this.w / this.radiusX) + 5;
+        this.rows = Math.ceil(AL.h / this.radiusY) + 5;
+        this.cols = Math.ceil(AL.w / this.radiusX) + 5;
     }
 
     setupDrawingStyles() {
-        this.ctx.lineWidth = 2;
-        this.ctx.globalAlpha = 0.33;
-        this.ctx.strokeStyle = 'black';
-        this.ctx.fillStyle = AL.randomColor(0, 255, 0.1, 0.5);
+        AL.ctx.lineWidth = 2;
+        AL.ctx.globalAlpha = 0.33;
+        AL.ctx.strokeStyle = 'black';
+        AL.ctx.fillStyle = AL.randomColor(0, 255, 0.1, 0.5);
     }
 
     draw() {
@@ -37,7 +37,7 @@ export default class RotationPatterns extends AL {
                 this.rotateCanvasDegrees(this.rotate);
 
                 for (let j = 0; j <= this.cols; j++) {
-                    this.ctx.strokeRect(
+                    AL.ctx.strokeRect(
                         this.radiusX * j,
                         this.radiusY * i,
                         this.radiusX,
@@ -50,7 +50,7 @@ export default class RotationPatterns extends AL {
         this.t += 1;
 
         if (this.t % (this.speed * 15) === 0) {
-            this.ctx.strokeStyle = AL.randomColor(0, 255, 0.1, 0.5);
+            AL.ctx.strokeStyle = AL.randomColor(0, 255, 0.1, 0.5);
         }
 
         if (this.t % (this.speed * 45) === 0) {
@@ -58,7 +58,7 @@ export default class RotationPatterns extends AL {
         }
 
         if (this.t % (this.speed * 90) === 0) {
-            this.ctx.lineWidth = AL.random(2, 9);
+            AL.ctx.lineWidth = AL.random(2, 9);
         }
 
         this.requestFrame();

--- a/src/algos/Rounded.js
+++ b/src/algos/Rounded.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Rounded extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Rounded';
 
@@ -18,25 +18,25 @@ export default class Rounded extends AL {
         this.rounded2 = AL.random(15, 50);
         this.rounded3 = AL.random(15, 50);
         this.rounded4 = AL.random(15, 50);
-        this.side1 = AL.random(0, this.w / 4);
-        this.side2 = AL.random(0, this.h / 4);
+        this.side1 = AL.random(0, AL.w / 4);
+        this.side2 = AL.random(0, AL.h / 4);
         this.rotate = (AL.random(1, 359) * Math.PI) / 180;
     }
 
     setupConstantStyles() {
-        this.ctx.filter = 'contrast(2)';
-        this.ctx.fillStyle = 'rgba(0, 0, 0, 0.3)';
+        AL.ctx.filter = 'contrast(2)';
+        AL.ctx.fillStyle = 'rgba(0, 0, 0, 0.3)';
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = AL.randomColor(50, 255, 0.5, 1);
+        AL.ctx.strokeStyle = AL.randomColor(50, 255, 0.5, 1);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.translate(this.w / 2, this.h / 2);
-            this.ctx.rotate(this.rotate);
-            this.ctx.roundRectExtra(
+            AL.ctx.translate(AL.w / 2, AL.h / 2);
+            AL.ctx.rotate(this.rotate);
+            AL.ctx.roundRectExtra(
                 this.side1,
                 this.side2,
                 this.side1,
@@ -50,7 +50,7 @@ export default class Rounded extends AL {
                 true,
                 true,
             );
-            this.ctx.translate(-this.w / 2, -this.h / 2);
+            AL.ctx.translate(-AL.w / 2, -AL.h / 2);
         }
 
         this.t += 1;
@@ -58,7 +58,7 @@ export default class Rounded extends AL {
         if (this.t % (this.speed * 125) === 0) {
             this.initializeProperties();
             this.setupDrawingStyles();
-            this.ctx.beginPath();
+            AL.ctx.beginPath();
         }
 
         this.requestFrame();

--- a/src/algos/Sandala.js
+++ b/src/algos/Sandala.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Sandala extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Sandala';
 
@@ -29,11 +29,11 @@ export default class Sandala extends AL {
     }
 
     setupConstantStyles() {
-        this.ctx.globalCompositeOperation = 'soft-light';
+        AL.ctx.globalCompositeOperation = 'soft-light';
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = AL.randomColor(0, 255, 1, 1);
+        AL.ctx.strokeStyle = AL.randomColor(0, 255, 1, 1);
     }
 
     draw() {
@@ -42,10 +42,10 @@ export default class Sandala extends AL {
                 this.rotateCanvasRadians(this.rotate);
 
                 for (let col = 0; col <= this.cols; col++) {
-                    this.ctx.strokeText(
+                    AL.ctx.strokeText(
                         String.fromCodePoint(AL.pickRandomElement(this.letters)),
-                        row * (this.w / this.cols),
-                        col * (this.h / this.rows),
+                        row * (AL.w / this.cols),
+                        col * (AL.h / this.rows),
                     );
                 }
             }

--- a/src/algos/Seeds.js
+++ b/src/algos/Seeds.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Seeds extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Seeds';
 
@@ -14,40 +14,40 @@ export default class Seeds extends AL {
     }
 
     initializeProperties() {
-        this.x1 = AL.random(0, this.w);
-        this.y1 = AL.random(0, this.h);
-        this.x2 = AL.random(0, this.w);
-        this.y2 = AL.random(0, this.h);
-        this.x3 = AL.random(0, this.w);
-        this.y3 = AL.random(0, this.h);
+        this.x1 = AL.random(0, AL.w);
+        this.y1 = AL.random(0, AL.h);
+        this.x2 = AL.random(0, AL.w);
+        this.y2 = AL.random(0, AL.h);
+        this.x3 = AL.random(0, AL.w);
+        this.y3 = AL.random(0, AL.h);
         this.rotate = AL.random(10, 101);
     }
 
     setupConstantStyles() {
-        this.ctx.shadowBlur = 2;
+        AL.ctx.shadowBlur = 2;
     }
 
     setupDrawingStyles() {
-        this.ctx.fillStyle =
-            this.ctx.strokeStyle =
-            this.ctx.shadowColor =
+        AL.ctx.fillStyle =
+            AL.ctx.strokeStyle =
+            AL.ctx.shadowColor =
                 AL.randomColor(40, 255, 0.65, 1);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.beginPath();
-            this.ctx.arc(this.x1, this.y1, 5, 0, 0.5 * Math.PI);
-            this.ctx.stroke();
-            this.ctx.fill();
-            this.ctx.beginPath();
-            this.ctx.arc(this.x2, this.y2, 10, 0, 0.5 * Math.PI);
-            this.ctx.stroke();
-            this.ctx.fill();
-            this.ctx.beginPath();
-            this.ctx.arc(this.x3, this.y3, 15, 0, 0.5 * Math.PI);
-            this.ctx.stroke();
-            this.ctx.fill();
+            AL.ctx.beginPath();
+            AL.ctx.arc(this.x1, this.y1, 5, 0, 0.5 * Math.PI);
+            AL.ctx.stroke();
+            AL.ctx.fill();
+            AL.ctx.beginPath();
+            AL.ctx.arc(this.x2, this.y2, 10, 0, 0.5 * Math.PI);
+            AL.ctx.stroke();
+            AL.ctx.fill();
+            AL.ctx.beginPath();
+            AL.ctx.arc(this.x3, this.y3, 15, 0, 0.5 * Math.PI);
+            AL.ctx.stroke();
+            AL.ctx.fill();
 
             this.x1 += 1;
             this.y1 -= 1;

--- a/src/algos/Shards.js
+++ b/src/algos/Shards.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Shards extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Shards';
 
@@ -36,23 +36,23 @@ export default class Shards extends AL {
 
     initializeProperties() {
         this.rotate = AL.random(1, 90);
-        this.c1x1 = AL.random(0, this.w);
-        this.c1y1 = AL.random(0, this.h);
-        this.c1x2 = AL.random(0, this.w);
-        this.c1y2 = AL.random(0, this.h);
+        this.c1x1 = AL.random(0, AL.w);
+        this.c1y1 = AL.random(0, AL.h);
+        this.c1x2 = AL.random(0, AL.w);
+        this.c1y2 = AL.random(0, AL.h);
         this.color = AL.randomColor(0, 255, 1, 1);
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = AL.randomColor(0, 255, 1, 1);
-        this.ctx.globalCompositeOperation = AL.pickRandomElement(this.modes);
+        AL.ctx.strokeStyle = AL.randomColor(0, 255, 1, 1);
+        AL.ctx.globalCompositeOperation = AL.pickRandomElement(this.modes);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.fillStyle = 'rgba(0, 0, 0, 0.01)';
+            AL.ctx.fillStyle = 'rgba(0, 0, 0, 0.01)';
             this.fillScreen();
-            this.ctx.fillStyle = this.color;
+            AL.ctx.fillStyle = this.color;
             this.drawTriangle();
         }
 
@@ -69,16 +69,16 @@ export default class Shards extends AL {
     }
 
     drawTriangle() {
-        this.ctx.beginPath();
-        this.ctx.moveTo(this.w / 2 + Math.sin(this.t) * 100, this.h / 2 + Math.cos(this.t) * 100);
-        this.ctx.lineTo(this.c1x1, this.c1y1);
-        this.ctx.lineTo(this.c1x2, this.c1y2);
-        this.ctx.lineTo(
-            this.w / 2 + Math.sin(this.t) * this.deviation,
-            this.h / 2 + Math.cos(this.t) * this.deviation,
+        AL.ctx.beginPath();
+        AL.ctx.moveTo(AL.w / 2 + Math.sin(this.t) * 100, AL.h / 2 + Math.cos(this.t) * 100);
+        AL.ctx.lineTo(this.c1x1, this.c1y1);
+        AL.ctx.lineTo(this.c1x2, this.c1y2);
+        AL.ctx.lineTo(
+            AL.w / 2 + Math.sin(this.t) * this.deviation,
+            AL.h / 2 + Math.cos(this.t) * this.deviation,
         );
-        this.ctx.stroke();
-        this.ctx.fill();
-        this.ctx.closePath();
+        AL.ctx.stroke();
+        AL.ctx.fill();
+        AL.ctx.closePath();
     }
 }

--- a/src/algos/Slices.js
+++ b/src/algos/Slices.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Slices extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Slices';
 
@@ -18,30 +18,30 @@ export default class Slices extends AL {
         this.slice = Math.random();
         this.radius = AL.random(70, 220);
         this.rotate = AL.random(2, 90);
-        this.offsetX = AL.random(50, this.w / 2);
-        this.offsetY = AL.random(50, this.h / 2);
+        this.offsetX = AL.random(50, AL.w / 2);
+        this.offsetY = AL.random(50, AL.h / 2);
         this.angleChange = Math.random() * 2 - 1;
     }
 
     setupConstantStyles() {
-        this.ctx.strokeStyle = 'black';
+        AL.ctx.strokeStyle = 'black';
     }
 
     setupDrawingStyles() {
-        this.ctx.fillStyle = AL.randomColor(30, 255, 0.3, 0.9);
+        AL.ctx.fillStyle = AL.randomColor(30, 255, 0.3, 0.9);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            const x = this.w / 2 + Math.sin(this.angle) * this.offsetX;
-            const y = this.h / 2 + Math.cos(this.angle) * this.offsetY;
+            const x = AL.w / 2 + Math.sin(this.angle) * this.offsetX;
+            const y = AL.h / 2 + Math.cos(this.angle) * this.offsetY;
             this.angle += this.angleChange;
 
-            this.ctx.beginPath();
-            this.ctx.arc(x, y, this.radius, 0, this.slice * Math.PI);
-            this.ctx.closePath();
-            this.ctx.fill();
-            this.ctx.stroke();
+            AL.ctx.beginPath();
+            AL.ctx.arc(x, y, this.radius, 0, this.slice * Math.PI);
+            AL.ctx.closePath();
+            AL.ctx.fill();
+            AL.ctx.stroke();
         }
 
         this.t += 1;

--- a/src/algos/Smooth.js
+++ b/src/algos/Smooth.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Smooth extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Smooth';
 
@@ -15,17 +15,17 @@ export default class Smooth extends AL {
     initializeProperties() {
         this.size = AL.random(50, 500);
         this.rotate = AL.random(1, 11);
-        this.x = AL.random(0, this.w);
-        this.y = AL.random(0, this.h);
+        this.x = AL.random(0, AL.w);
+        this.y = AL.random(0, AL.h);
     }
 
     setupDrawingStyles() {
-        this.ctx.fillStyle = AL.randomColor(0, 255, 0.03, 0.08);
+        AL.ctx.fillStyle = AL.randomColor(0, 255, 0.03, 0.08);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.fillRect(this.x, this.y, this.size, this.size);
+            AL.ctx.fillRect(this.x, this.y, this.size, this.size);
         }
 
         this.t += 1;

--- a/src/algos/SnakesLadders.js
+++ b/src/algos/SnakesLadders.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class SnakesLadders extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Snakes n Ladders';
 
@@ -23,22 +23,22 @@ export default class SnakesLadders extends AL {
         this.div = AL.random(3, 17);
         this.div2 = AL.random(3, 17);
         this.rotate = AL.random(1, 83);
-        this.colSize = this.w / this.div;
-        this.rowSize = this.h / this.div2;
+        this.colSize = AL.w / this.div;
+        this.rowSize = AL.h / this.div2;
     }
 
     setupConstantStyles() {
-        this.ctx.shadowBlur = 3;
+        AL.ctx.shadowBlur = 3;
     }
 
     setupDrawingStyles() {
-        this.ctx.fillStyle = AL.randomColor(0, 255, 0.12, 0.37);
-        this.ctx.strokeStyle = this.ctx.shadowColor = AL.randomColor(0, 255, 0.65, 1);
+        AL.ctx.fillStyle = AL.randomColor(0, 255, 0.12, 0.37);
+        AL.ctx.strokeStyle = AL.ctx.shadowColor = AL.randomColor(0, 255, 0.65, 1);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.strokeRect(
+            AL.ctx.strokeRect(
                 this.colSize * this.currCol,
                 this.rowSize * this.currRow,
                 this.colSize,
@@ -65,7 +65,7 @@ export default class SnakesLadders extends AL {
             this.initializeProperties();
             this.fillScreen();
             this.setupDrawingStyles();
-            this.ctx.beginPath();
+            AL.ctx.beginPath();
         }
 
         this.requestFrame();

--- a/src/algos/SoapyBubbles.js
+++ b/src/algos/SoapyBubbles.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class SoapyBubbles extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Soapy Bubbles';
 
@@ -26,20 +26,20 @@ export default class SoapyBubbles extends AL {
     }
 
     setupConstantStyles() {
-        this.ctx.shadowBlur = 30;
-        this.ctx.fillStyle = 'rgba(0, 0, 0, 0.6)';
+        AL.ctx.shadowBlur = 30;
+        AL.ctx.fillStyle = 'rgba(0, 0, 0, 0.6)';
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = this.ctx.shadowColor = AL.randomColor(50, 255, 0.5, 1);
+        AL.ctx.strokeStyle = AL.ctx.shadowColor = AL.randomColor(50, 255, 0.5, 1);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.beginPath();
-            this.ctx.arc(this.position.x, this.position.y, this.size, 0, 2 * Math.PI);
-            this.ctx.stroke();
-            this.ctx.fill();
+            AL.ctx.beginPath();
+            AL.ctx.arc(this.position.x, this.position.y, this.size, 0, 2 * Math.PI);
+            AL.ctx.stroke();
+            AL.ctx.fill();
 
             this.position.addTo(this.velocity);
         }

--- a/src/algos/Solar.js
+++ b/src/algos/Solar.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Solar extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Solar';
 
@@ -14,29 +14,29 @@ export default class Solar extends AL {
     }
 
     initializeProperties() {
-        this.x1 = AL.random(0, this.w);
-        this.y1 = AL.random(0, this.h);
-        this.x2 = AL.random(0, this.w);
-        this.y2 = AL.random(0, this.h);
+        this.x1 = AL.random(0, AL.w);
+        this.y1 = AL.random(0, AL.h);
+        this.x2 = AL.random(0, AL.w);
+        this.y2 = AL.random(0, AL.h);
         this.rotate = AL.random(1, 359);
     }
 
     setupConstantStyles() {
-        this.ctx.globalCompositeOperation = 'hard-light';
+        AL.ctx.globalCompositeOperation = 'hard-light';
         this.colors = AL.generateHSLAPalette(7, 'random');
         this.colorIndex = 0;
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = this.colors[this.colorIndex];
-        this.ctx.lineWidth = AL.random(1, 4);
+        AL.ctx.strokeStyle = this.colors[this.colorIndex];
+        AL.ctx.lineWidth = AL.random(1, 4);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.moveTo(0, 0);
-            this.ctx.bezierCurveTo(this.x1, this.y1, this.x2, this.y2, this.w, this.h);
-            this.ctx.stroke();
+            AL.ctx.moveTo(0, 0);
+            AL.ctx.bezierCurveTo(this.x1, this.y1, this.x2, this.y2, AL.w, AL.h);
+            AL.ctx.stroke();
         }
 
         this.t += 1;
@@ -47,7 +47,7 @@ export default class Solar extends AL {
             this.colorIndex = (this.colorIndex + 1) % this.colors.length;
             this.initializeProperties();
             this.setupDrawingStyles();
-            this.ctx.beginPath();
+            AL.ctx.beginPath();
         }
 
         this.requestFrame();

--- a/src/algos/SpaceGears.js
+++ b/src/algos/SpaceGears.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class SpaceGears extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Space Gears';
 
@@ -27,19 +27,19 @@ export default class SpaceGears extends AL {
     }
 
     setupDrawingStyles() {
-        this.ctx.font = `${AL.random(100, 700)}px serif`;
-        this.ctx.strokeStyle = AL.randomColor(0, 255, 0.6, 0.6);
+        AL.ctx.font = `${AL.random(100, 700)}px serif`;
+        AL.ctx.strokeStyle = AL.randomColor(0, 255, 0.6, 0.6);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.textAlign = 'left';
-            this.ctx.strokeText(` ${this.letter.repeat(3)}`, 0, 0);
-            this.ctx.translate(this.w / 2, this.h / 2);
-            this.ctx.rotate(this.rotate);
-            this.ctx.textAlign = 'center';
-            this.ctx.strokeText(this.letter, 0, 0);
-            this.ctx.translate(-this.w / 2, -this.h / 2);
+            AL.ctx.textAlign = 'left';
+            AL.ctx.strokeText(` ${this.letter.repeat(3)}`, 0, 0);
+            AL.ctx.translate(AL.w / 2, AL.h / 2);
+            AL.ctx.rotate(this.rotate);
+            AL.ctx.textAlign = 'center';
+            AL.ctx.strokeText(this.letter, 0, 0);
+            AL.ctx.translate(-AL.w / 2, -AL.h / 2);
         }
 
         this.t += 1;

--- a/src/algos/Spikey.js
+++ b/src/algos/Spikey.js
@@ -2,8 +2,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Spikey extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Spikey';
 
@@ -19,21 +19,21 @@ export default class Spikey extends AL {
         this.rounded2 = AL.random(75, 475);
         this.rounded3 = AL.random(75, 475);
         this.rounded4 = AL.random(75, 475);
-        this.side1 = AL.random(0, this.w / 4);
-        this.side2 = AL.random(0, this.h / 4);
-        this.side3 = AL.random(0, this.w / 4);
-        this.side4 = AL.random(0, this.h / 4);
+        this.side1 = AL.random(0, AL.w / 4);
+        this.side2 = AL.random(0, AL.h / 4);
+        this.side3 = AL.random(0, AL.w / 4);
+        this.side4 = AL.random(0, AL.h / 4);
         this.rotate = (AL.random(2, 358) * Math.PI) / 180;
     }
 
     setupConstantStyles() {
-        this.ctx.beginPath();
-        this.ctx.lineWidth = 0.25;
-        this.ctx.moveTo(this.w / 2, this.h / 2);
+        AL.ctx.beginPath();
+        AL.ctx.lineWidth = 0.25;
+        AL.ctx.moveTo(AL.w / 2, AL.h / 2);
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = AL.randomColor(60, 255, 1, 1);
+        AL.ctx.strokeStyle = AL.randomColor(60, 255, 1, 1);
     }
 
     draw() {
@@ -41,9 +41,9 @@ export default class Spikey extends AL {
             this.stagger %= 2;
 
             if (this.stagger === 0) {
-                this.ctx.translate(this.w / 2, this.h / 2);
-                this.ctx.rotate(this.rotate);
-                this.ctx.roundRectExtra(
+                AL.ctx.translate(AL.w / 2, AL.h / 2);
+                AL.ctx.rotate(this.rotate);
+                AL.ctx.roundRectExtra(
                     this.side1--,
                     this.side2--,
                     this.side1--,
@@ -57,13 +57,13 @@ export default class Spikey extends AL {
                     false,
                     true,
                 );
-                this.ctx.translate(-this.w / 2, -this.h / 2);
+                AL.ctx.translate(-AL.w / 2, -AL.h / 2);
             }
 
             if (this.stagger === 1) {
-                this.ctx.translate(this.w / 2, this.h / 2);
-                this.ctx.rotate(this.rotate);
-                this.ctx.roundRectExtra(
+                AL.ctx.translate(AL.w / 2, AL.h / 2);
+                AL.ctx.rotate(this.rotate);
+                AL.ctx.roundRectExtra(
                     this.side3++,
                     this.side4++,
                     this.side3++,
@@ -78,7 +78,7 @@ export default class Spikey extends AL {
                     true,
                 );
 
-                this.ctx.translate(-this.w / 2, -this.h / 2);
+                AL.ctx.translate(-AL.w / 2, -AL.h / 2);
             }
 
             this.stagger += 1;
@@ -89,12 +89,12 @@ export default class Spikey extends AL {
         if (this.t % (this.speed * 400) === 0) {
             this.initializeProperties();
 
-            this.ctx.save();
-            this.ctx.resetTransform();
+            AL.ctx.save();
+            AL.ctx.resetTransform();
             this.clearScreen();
-            this.ctx.restore();
+            AL.ctx.restore();
 
-            this.ctx.beginPath();
+            AL.ctx.beginPath();
             this.setupDrawingStyles();
         }
 

--- a/src/algos/Spikral.js
+++ b/src/algos/Spikral.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Spikral extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Spikral';
 
@@ -23,14 +23,14 @@ export default class Spikral extends AL {
     }
 
     setupDrawingStyles() {
-        this.ctx.fillStyle = AL.randomColor(0, 255, 0.25, 1);
+        AL.ctx.fillStyle = AL.randomColor(0, 255, 0.25, 1);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.arc(this.w / 2, this.h / 2, this.size, 0, this.fillAmount);
-            this.ctx.fill();
-            this.ctx.beginPath();
+            AL.ctx.arc(AL.w / 2, AL.h / 2, this.size, 0, this.fillAmount);
+            AL.ctx.fill();
+            AL.ctx.beginPath();
 
             this.size *= 1.06;
         }

--- a/src/algos/Spinner.js
+++ b/src/algos/Spinner.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Spinner extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Spinner';
 
@@ -14,34 +14,34 @@ export default class Spinner extends AL {
     initializeProperties() {
         this.gap1 = AL.random(15, 150);
         this.gap2 = AL.random(-150, -15);
-        this.side = Math.min(this.w, this.h);
+        this.side = Math.min(AL.w, AL.h);
         this.color1 = AL.randomColor(0, 255, 1, 1);
         this.color2 = AL.randomColor(0, 255, 1, 1);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.translate(this.w / 2, this.h / 2);
-            this.ctx.rotate((this.gap1 * Math.PI) / 180);
-            this.ctx.lineWidth = 2;
-            this.ctx.globalCompositeOperation = 'hard-light';
-            this.ctx.globalAlpha = 0.08;
-            this.ctx.shadowColor = this.ctx.fillStyle = this.color1;
-            this.ctx.shadowBlur = 8;
-            this.ctx.fillRect(
-                this.w / 2 - this.side / 2,
-                this.h / 2 - this.side / 2,
+            AL.ctx.translate(AL.w / 2, AL.h / 2);
+            AL.ctx.rotate((this.gap1 * Math.PI) / 180);
+            AL.ctx.lineWidth = 2;
+            AL.ctx.globalCompositeOperation = 'hard-light';
+            AL.ctx.globalAlpha = 0.08;
+            AL.ctx.shadowColor = AL.ctx.fillStyle = this.color1;
+            AL.ctx.shadowBlur = 8;
+            AL.ctx.fillRect(
+                AL.w / 2 - this.side / 2,
+                AL.h / 2 - this.side / 2,
                 this.side,
                 this.side,
             );
 
-            this.ctx.translate(-this.w / 2, -this.h / 2);
-            this.ctx.lineWidth = 3;
-            this.ctx.globalAlpha = 0.2;
-            this.ctx.shadowBlur = 0;
-            this.ctx.globalCompositeOperation = 'difference';
-            this.ctx.fillStyle = this.color2;
-            this.ctx.fillRect(this.w / 2, this.h / 2, this.gap1 * 2, this.gap2 * 2);
+            AL.ctx.translate(-AL.w / 2, -AL.h / 2);
+            AL.ctx.lineWidth = 3;
+            AL.ctx.globalAlpha = 0.2;
+            AL.ctx.shadowBlur = 0;
+            AL.ctx.globalCompositeOperation = 'difference';
+            AL.ctx.fillStyle = this.color2;
+            AL.ctx.fillRect(AL.w / 2, AL.h / 2, this.gap1 * 2, this.gap2 * 2);
         }
 
         this.t += 1;
@@ -50,11 +50,11 @@ export default class Spinner extends AL {
             this.gap1 = AL.random(15, 150);
             this.gap2 = AL.random(-150, -15);
             this.color2 = AL.randomColor(0, 255, 1, 1);
-            this.side = AL.random(200, Math.max(this.w, this.h) / 2);
+            this.side = AL.random(200, Math.max(AL.w, AL.h) / 2);
         }
 
         if (this.t % (this.speed * 100) === 0) {
-            this.ctx.beginPath();
+            AL.ctx.beginPath();
             this.color1 = AL.randomColor(0, 255, 1, 1);
         }
 

--- a/src/algos/SpiralLines.js
+++ b/src/algos/SpiralLines.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class SpiralLines extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Spiral Lines';
 
@@ -17,15 +17,15 @@ export default class SpiralLines extends AL {
         this.bw = Math.random();
         this.gap = AL.random(4, 100);
         this.rotate = AL.random(1, 359);
-        this.radius = AL.random(10, this.h);
-        this.length = AL.random(50, Math.min(this.w, this.h) / 1.5);
+        this.radius = AL.random(10, AL.h);
+        this.length = AL.random(50, Math.min(AL.w, AL.h) / 1.5);
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = AL.randomColor(5, 255, 0.5, 0.5);
-        this.ctx.moveTo(this.w / 2, this.h / 2);
-        this.ctx.lineWidth = AL.random(1, 8);
-        this.ctx.beginPath();
+        AL.ctx.strokeStyle = AL.randomColor(5, 255, 0.5, 0.5);
+        AL.ctx.moveTo(AL.w / 2, AL.h / 2);
+        AL.ctx.lineWidth = AL.random(1, 8);
+        AL.ctx.beginPath();
     }
 
     draw() {
@@ -33,40 +33,31 @@ export default class SpiralLines extends AL {
             this.stagger %= 3;
 
             if (this.stagger === 0) {
-                this.ctx.moveTo(
-                    this.w / 2 - this.radius - this.length / 2,
-                    this.h / 2 + this.length / 2,
-                );
-                this.ctx.lineTo(
-                    this.w / 2 - this.radius - this.length / 2,
-                    this.h / 2 - this.length / 2,
-                );
-                this.ctx.stroke();
+                AL.ctx.moveTo(AL.w / 2 - this.radius - this.length / 2, AL.h / 2 + this.length / 2);
+                AL.ctx.lineTo(AL.w / 2 - this.radius - this.length / 2, AL.h / 2 - this.length / 2);
+                AL.ctx.stroke();
             }
 
             if (this.stagger === 1) {
-                this.ctx.lineTo(this.w / 2 - this.radius - this.length, this.h / 2);
-                this.ctx.stroke();
+                AL.ctx.lineTo(AL.w / 2 - this.radius - this.length, AL.h / 2);
+                AL.ctx.stroke();
             }
 
             if (this.stagger === 2) {
-                this.ctx.lineTo(
-                    this.w / 2 - this.radius - this.length / 2,
-                    this.h / 2 + this.length / 2,
-                );
-                this.ctx.stroke();
+                AL.ctx.lineTo(AL.w / 2 - this.radius - this.length / 2, AL.h / 2 + this.length / 2);
+                AL.ctx.stroke();
             }
 
             this.rotateCanvasDegrees(this.rotate);
 
             this.length += this.gap;
-            if (this.length > Math.max(this.w, this.h)) {
+            if (this.length > Math.max(AL.w, AL.h)) {
                 this.cycles += 1;
                 this.length = this.gap;
 
-                this.ctx.beginPath();
-                this.ctx.strokeStyle = AL.randomColor(5, 255, 0.5, 0.5);
-                this.ctx.arc(this.w / 2, this.h / 2, this.radius, 0, 360);
+                AL.ctx.beginPath();
+                AL.ctx.strokeStyle = AL.randomColor(5, 255, 0.5, 0.5);
+                AL.ctx.arc(AL.w / 2, AL.h / 2, this.radius, 0, 360);
 
                 this.bw = Math.random();
                 this.radius = AL.random(5, 65);
@@ -78,8 +69,8 @@ export default class SpiralLines extends AL {
 
         if (this.cycles % 9 === 0) {
             this.bw < 0.5
-                ? (this.ctx.strokeStyle = 'rgba(255,255,255, .75)')
-                : (this.ctx.strokeStyle = 'rgba(0,0,0, .75)');
+                ? (AL.ctx.strokeStyle = 'rgba(255,255,255, .75)')
+                : (AL.ctx.strokeStyle = 'rgba(0,0,0, .75)');
         }
 
         this.requestFrame();

--- a/src/algos/SpiralText.js
+++ b/src/algos/SpiralText.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class SpiralText extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Spiral Text';
 
@@ -14,51 +14,51 @@ export default class SpiralText extends AL {
     }
 
     initializeProperties() {
-        this.x = AL.random(0, this.w);
-        this.y = AL.random(0, this.h);
+        this.x = AL.random(0, AL.w);
+        this.y = AL.random(0, AL.h);
         this.rotate = AL.random(1, 20);
         this.picker = AL.random(0, 11);
     }
 
     setupConstantStyles() {
-        this.ctx.textAlign = 'center';
-        this.ctx.globalCompositeOperation = 'color';
+        AL.ctx.textAlign = 'center';
+        AL.ctx.globalCompositeOperation = 'color';
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = AL.randomColor(0, 255, 1, 1);
-        this.ctx.font = `bold ${AL.random(10, 400)}px sans-serif`;
+        AL.ctx.strokeStyle = AL.randomColor(0, 255, 1, 1);
+        AL.ctx.font = `bold ${AL.random(10, 400)}px sans-serif`;
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.strokeText('SPIRAL', this.x, this.y);
+            AL.ctx.strokeText('SPIRAL', this.x, this.y);
 
             this.rotateCanvasDegrees(this.rotate);
 
-            this.x = AL.random(0, this.w);
+            this.x = AL.random(0, AL.w);
         }
 
         this.t += 1;
 
         if (this.t % (this.speed * 90) === 0) {
-            this.y = AL.random(0, this.h);
+            this.y = AL.random(0, AL.h);
             this.picker = AL.random(0, 11);
 
             if (this.picker === 0) {
-                this.ctx.strokeStyle = 'white';
+                AL.ctx.strokeStyle = 'white';
             } else if (this.picker === 1) {
-                this.ctx.strokeStyle = 'black';
+                AL.ctx.strokeStyle = 'black';
             } else if (this.picker === 2 || this.picker === 3) {
-                this.ctx.globalCompositeOperation = 'color-dodge';
+                AL.ctx.globalCompositeOperation = 'color-dodge';
             } else if (this.picker === 4 || this.picker === 5) {
-                this.ctx.globalCompositeOperation = 'source-over';
+                AL.ctx.globalCompositeOperation = 'source-over';
             } else if (this.picker === 6) {
-                this.ctx.globalCompositeOperation = 'darken';
+                AL.ctx.globalCompositeOperation = 'darken';
             } else if (this.picker === 7) {
-                this.ctx.globalCompositeOperation = 'color-burn';
+                AL.ctx.globalCompositeOperation = 'color-burn';
             } else {
-                this.ctx.globalCompositeOperation = 'color';
+                AL.ctx.globalCompositeOperation = 'color';
             }
 
             this.setupDrawingStyles();

--- a/src/algos/SpringOrbits.js
+++ b/src/algos/SpringOrbits.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class SpringOrbits extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Spring Orbits';
 
@@ -16,48 +16,48 @@ export default class SpringOrbits extends AL {
 
     initializeBaseProperties() {
         this.k = 0.02;
-        this.springPoint = { x: this.w / 2, y: this.h / 2 };
+        this.springPoint = { x: AL.w / 2, y: AL.h / 2 };
     }
 
     initializeProperties() {
-        this.weight = AL.createParticle(
-            AL.random(0, this.w),
-            AL.random(0, this.h),
+        AL.weight = AL.createParticle(
+            AL.random(0, AL.w),
+            AL.random(0, AL.h),
             AL.random(15, 120),
             Math.random() * Math.PI * 2,
         );
-        this.weight.friction = 0.99;
+        AL.weight.friction = 0.99;
     }
 
     setupConstantStyles() {
-        this.ctx.lineWidth = 3;
-        this.ctx.shadowBlur = 2;
-        this.ctx.fillStyle = 'white';
+        AL.ctx.lineWidth = 3;
+        AL.ctx.shadowBlur = 2;
+        AL.ctx.fillStyle = 'white';
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = this.ctx.shadowColor = AL.randomColor();
+        AL.ctx.strokeStyle = AL.ctx.shadowColor = AL.randomColor();
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            const dx = this.springPoint.x - this.weight.x;
-            const dy = this.springPoint.y - this.weight.y;
+            const dx = this.springPoint.x - AL.weight.x;
+            const dy = this.springPoint.y - AL.weight.y;
             const distance = Math.hypot(dx, dy);
             const springForce = distance * this.k;
             const ax = (dx / distance) * springForce;
             const ay = (dy / distance) * springForce;
-            this.weight.vx += ax;
-            this.weight.vy += ay;
-            this.weight.update();
+            AL.weight.vx += ax;
+            AL.weight.vy += ay;
+            AL.weight.update();
 
-            this.ctx.beginPath();
-            this.ctx.arc(this.springPoint.x, this.springPoint.y, 8, 0, 2 * Math.PI);
-            this.ctx.fill();
-            this.ctx.beginPath();
-            this.ctx.moveTo(this.weight.x, this.weight.y);
-            this.ctx.lineTo(this.springPoint.x, this.springPoint.y);
-            this.ctx.stroke();
+            AL.ctx.beginPath();
+            AL.ctx.arc(this.springPoint.x, this.springPoint.y, 8, 0, 2 * Math.PI);
+            AL.ctx.fill();
+            AL.ctx.beginPath();
+            AL.ctx.moveTo(AL.weight.x, AL.weight.y);
+            AL.ctx.lineTo(this.springPoint.x, this.springPoint.y);
+            AL.ctx.stroke();
         }
 
         this.t += 1;

--- a/src/algos/SquareNebulas.js
+++ b/src/algos/SquareNebulas.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class SquareNebulas extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Square Nebulas';
 
@@ -13,14 +13,14 @@ export default class SquareNebulas extends AL {
     }
 
     initializeProperties() {
-        this.length = AL.random(50, Math.min(this.w, this.h) / 1.5);
+        this.length = AL.random(50, Math.min(AL.w, AL.h) / 1.5);
         this.maxLength = this.length;
         this.gap = AL.random(4, 100);
     }
 
     setupDrawingStyles() {
-        this.ctx.fillStyle = AL.randomColor(5, 255, 0.025, 0.025);
-        this.ctx.strokeStyle = AL.randomColor(5, 255, 0.8, 0.8);
+        AL.ctx.fillStyle = AL.randomColor(5, 255, 0.025, 0.025);
+        AL.ctx.strokeStyle = AL.randomColor(5, 255, 0.8, 0.8);
     }
 
     draw() {
@@ -28,42 +28,37 @@ export default class SquareNebulas extends AL {
             this.stagger %= 3;
 
             if (this.stagger === 0) {
-                this.ctx.beginPath();
-                this.ctx.moveTo(this.w / 2, this.h / 2);
-                this.ctx.fillRect(
-                    AL.random(0, this.w),
-                    AL.random(0, this.h),
-                    this.length,
-                    this.length,
-                );
-                this.ctx.stroke();
-                this.ctx.closePath();
+                AL.ctx.beginPath();
+                AL.ctx.moveTo(AL.w / 2, AL.h / 2);
+                AL.ctx.fillRect(AL.random(0, AL.w), AL.random(0, AL.h), this.length, this.length);
+                AL.ctx.stroke();
+                AL.ctx.closePath();
             }
 
             if (this.stagger === 1) {
-                this.ctx.strokeRect(this.w / 2, this.h / 2, this.length / 2, this.length / 2);
-                this.ctx.stroke();
-                this.ctx.closePath();
+                AL.ctx.strokeRect(AL.w / 2, AL.h / 2, this.length / 2, this.length / 2);
+                AL.ctx.stroke();
+                AL.ctx.closePath();
             }
 
             if (this.stagger === 2) {
-                this.ctx.fillRect(
-                    AL.random(this.w / 2, this.w / 2 + this.length),
-                    AL.random(this.h / 2, this.h / 2 + this.length),
+                AL.ctx.fillRect(
+                    AL.random(AL.w / 2, AL.w / 2 + this.length),
+                    AL.random(AL.h / 2, AL.h / 2 + this.length),
                     this.length / 8,
                     this.length / 8,
                 );
-                this.ctx.fill();
-                this.ctx.closePath();
+                AL.ctx.fill();
+                AL.ctx.closePath();
                 this.rotateCanvasRadians(Math.random() * Math.PI);
             }
 
-            this.ctx.moveTo(this.w / 2, this.h / 2);
+            AL.ctx.moveTo(AL.w / 2, AL.h / 2);
             this.rotateCanvasRadians(Math.random() * Math.PI);
 
             this.length -= this.gap;
             if (this.length < -this.maxLength) {
-                this.length = AL.random(this.maxLength / 2, this.w / 3);
+                this.length = AL.random(this.maxLength / 2, AL.w / 3);
                 this.maxLength = 2 * this.length;
                 this.gap = AL.random(2, 100);
             }
@@ -74,8 +69,8 @@ export default class SquareNebulas extends AL {
         this.t += 1;
 
         if (this.t % (this.speed * 300) === 0) {
-            this.ctx.closePath();
-            this.ctx.beginPath();
+            AL.ctx.closePath();
+            AL.ctx.beginPath();
             this.setupDrawingStyles();
             this.rotateCanvasRadians(Math.random() * Math.PI);
         }

--- a/src/algos/StainedGlass.js
+++ b/src/algos/StainedGlass.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class StainedGlass extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Stained Glass';
 
@@ -14,8 +14,8 @@ export default class StainedGlass extends AL {
     }
 
     initializeProperties() {
-        this.length = this.w / 6;
-        this.height = this.h / 5;
+        this.length = AL.w / 6;
+        this.height = AL.h / 5;
         this.random1 = AL.random(0, 3);
         this.random2 = AL.random(1, 359);
     }
@@ -23,14 +23,14 @@ export default class StainedGlass extends AL {
     setupConstantStyles() {
         this.modes = ['color', 'hue', 'saturation', 'overlay'];
 
-        this.ctx.beginPath();
-        this.ctx.lineWidth = 5;
-        this.ctx.strokeStyle = 'black';
-        this.ctx.globalCompositeOperation = 'color';
+        AL.ctx.beginPath();
+        AL.ctx.lineWidth = 5;
+        AL.ctx.strokeStyle = 'black';
+        AL.ctx.globalCompositeOperation = 'color';
     }
 
     setupDrawingStyles() {
-        this.ctx.fillStyle = AL.randomColor(0, 255, 0, 1);
+        AL.ctx.fillStyle = AL.randomColor(0, 255, 0, 1);
     }
 
     draw() {
@@ -38,182 +38,182 @@ export default class StainedGlass extends AL {
             this.stagger = AL.random(0, 30);
 
             if (this.stagger === 0) {
-                this.ctx.strokeRect(0, 0, this.length, this.height);
-                this.ctx.fillRect(0, 0, this.length, this.height);
+                AL.ctx.strokeRect(0, 0, this.length, this.height);
+                AL.ctx.fillRect(0, 0, this.length, this.height);
                 this.setupDrawingStyles();
             }
 
             if (this.stagger === 1) {
-                this.ctx.strokeRect(this.length, 0, this.length, this.height);
-                this.ctx.fillRect(this.length, 0, this.length, this.height);
+                AL.ctx.strokeRect(this.length, 0, this.length, this.height);
+                AL.ctx.fillRect(this.length, 0, this.length, this.height);
                 this.setupDrawingStyles();
             }
 
             if (this.stagger === 2) {
-                this.ctx.strokeRect(2 * this.length, 0, this.length, this.height);
-                this.ctx.fillRect(2 * this.length, 0, this.length, this.height);
+                AL.ctx.strokeRect(2 * this.length, 0, this.length, this.height);
+                AL.ctx.fillRect(2 * this.length, 0, this.length, this.height);
                 this.setupDrawingStyles();
             }
 
             if (this.stagger === 3) {
-                this.ctx.strokeRect(3 * this.length, 0, this.length, this.height);
-                this.ctx.fillRect(3 * this.length, 0, this.length, this.height);
+                AL.ctx.strokeRect(3 * this.length, 0, this.length, this.height);
+                AL.ctx.fillRect(3 * this.length, 0, this.length, this.height);
                 this.setupDrawingStyles();
             }
 
             if (this.stagger === 4) {
-                this.ctx.strokeRect(4 * this.length, 0, this.length, this.height);
-                this.ctx.fillRect(4 * this.length, 0, this.length, this.height);
+                AL.ctx.strokeRect(4 * this.length, 0, this.length, this.height);
+                AL.ctx.fillRect(4 * this.length, 0, this.length, this.height);
                 this.setupDrawingStyles();
             }
 
             if (this.stagger === 5) {
-                this.ctx.strokeRect(5 * this.length, 0, this.length, this.height);
-                this.ctx.fillRect(5 * this.length, 0, this.length, this.height);
+                AL.ctx.strokeRect(5 * this.length, 0, this.length, this.height);
+                AL.ctx.fillRect(5 * this.length, 0, this.length, this.height);
                 this.setupDrawingStyles();
             }
 
             if (this.stagger === 6) {
-                this.ctx.strokeRect(5 * this.length, this.height, this.length, this.height);
-                this.ctx.fillRect(5 * this.length, this.height, this.length, this.height);
+                AL.ctx.strokeRect(5 * this.length, this.height, this.length, this.height);
+                AL.ctx.fillRect(5 * this.length, this.height, this.length, this.height);
                 this.setupDrawingStyles();
             }
 
             if (this.stagger === 7) {
-                this.ctx.strokeRect(4 * this.length, this.height, this.length, this.height);
-                this.ctx.fillRect(4 * this.length, this.height, this.length, this.height);
+                AL.ctx.strokeRect(4 * this.length, this.height, this.length, this.height);
+                AL.ctx.fillRect(4 * this.length, this.height, this.length, this.height);
                 this.setupDrawingStyles();
             }
 
             if (this.stagger === 8) {
-                this.ctx.strokeRect(3 * this.length, this.height, this.length, this.height);
-                this.ctx.fillRect(3 * this.length, this.height, this.length, this.height);
+                AL.ctx.strokeRect(3 * this.length, this.height, this.length, this.height);
+                AL.ctx.fillRect(3 * this.length, this.height, this.length, this.height);
                 this.setupDrawingStyles();
             }
 
             if (this.stagger === 9) {
-                this.ctx.strokeRect(2 * this.length, this.height, this.length, this.height);
-                this.ctx.fillRect(2 * this.length, this.height, this.length, this.height);
+                AL.ctx.strokeRect(2 * this.length, this.height, this.length, this.height);
+                AL.ctx.fillRect(2 * this.length, this.height, this.length, this.height);
                 this.setupDrawingStyles();
             }
 
             if (this.stagger === 10) {
-                this.ctx.strokeRect(this.length, this.height, this.length, this.height);
-                this.ctx.fillRect(this.length, this.height, this.length, this.height);
+                AL.ctx.strokeRect(this.length, this.height, this.length, this.height);
+                AL.ctx.fillRect(this.length, this.height, this.length, this.height);
                 this.setupDrawingStyles();
             }
 
             if (this.stagger === 11) {
-                this.ctx.strokeRect(0, this.height, this.length, this.height);
-                this.ctx.fillRect(0, this.height, this.length, this.height);
+                AL.ctx.strokeRect(0, this.height, this.length, this.height);
+                AL.ctx.fillRect(0, this.height, this.length, this.height);
                 this.setupDrawingStyles();
             }
 
             if (this.stagger === 12) {
-                this.ctx.strokeRect(0, 2 * this.height, this.length, this.height);
-                this.ctx.fillRect(0, 2 * this.height, this.length, this.height);
+                AL.ctx.strokeRect(0, 2 * this.height, this.length, this.height);
+                AL.ctx.fillRect(0, 2 * this.height, this.length, this.height);
                 this.setupDrawingStyles();
             }
 
             if (this.stagger === 13) {
-                this.ctx.strokeRect(this.length, 2 * this.height, this.length, this.height);
-                this.ctx.fillRect(this.length, 2 * this.height, this.length, this.height);
+                AL.ctx.strokeRect(this.length, 2 * this.height, this.length, this.height);
+                AL.ctx.fillRect(this.length, 2 * this.height, this.length, this.height);
                 this.setupDrawingStyles();
             }
 
             if (this.stagger === 14) {
-                this.ctx.strokeRect(2 * this.length, 2 * this.height, this.length, this.height);
-                this.ctx.fillRect(2 * this.length, 2 * this.height, this.length, this.height);
+                AL.ctx.strokeRect(2 * this.length, 2 * this.height, this.length, this.height);
+                AL.ctx.fillRect(2 * this.length, 2 * this.height, this.length, this.height);
                 this.setupDrawingStyles();
             }
 
             if (this.stagger === 15) {
-                this.ctx.strokeRect(3 * this.length, 2 * this.height, this.length, this.height);
-                this.ctx.fillRect(3 * this.length, 2 * this.height, this.length, this.height);
+                AL.ctx.strokeRect(3 * this.length, 2 * this.height, this.length, this.height);
+                AL.ctx.fillRect(3 * this.length, 2 * this.height, this.length, this.height);
                 this.setupDrawingStyles();
             }
 
             if (this.stagger === 16) {
-                this.ctx.strokeRect(4 * this.length, 2 * this.height, this.length, this.height);
-                this.ctx.fillRect(4 * this.length, 2 * this.height, this.length, this.height);
+                AL.ctx.strokeRect(4 * this.length, 2 * this.height, this.length, this.height);
+                AL.ctx.fillRect(4 * this.length, 2 * this.height, this.length, this.height);
                 this.setupDrawingStyles();
             }
 
             if (this.stagger === 17) {
-                this.ctx.strokeRect(5 * this.length, 2 * this.height, this.length, this.height);
-                this.ctx.fillRect(5 * this.length, 2 * this.height, this.length, this.height);
+                AL.ctx.strokeRect(5 * this.length, 2 * this.height, this.length, this.height);
+                AL.ctx.fillRect(5 * this.length, 2 * this.height, this.length, this.height);
                 this.setupDrawingStyles();
             }
 
             if (this.stagger === 18) {
-                this.ctx.strokeRect(5 * this.length, 3 * this.height, this.length, this.height);
-                this.ctx.fillRect(5 * this.length, 3 * this.height, this.length, this.height);
+                AL.ctx.strokeRect(5 * this.length, 3 * this.height, this.length, this.height);
+                AL.ctx.fillRect(5 * this.length, 3 * this.height, this.length, this.height);
                 this.setupDrawingStyles();
             }
 
             if (this.stagger === 19) {
-                this.ctx.strokeRect(4 * this.length, 3 * this.height, this.length, this.height);
-                this.ctx.fillRect(4 * this.length, 3 * this.height, this.length, this.height);
+                AL.ctx.strokeRect(4 * this.length, 3 * this.height, this.length, this.height);
+                AL.ctx.fillRect(4 * this.length, 3 * this.height, this.length, this.height);
                 this.setupDrawingStyles();
             }
 
             if (this.stagger === 20) {
-                this.ctx.strokeRect(3 * this.length, 3 * this.height, this.length, this.height);
-                this.ctx.fillRect(3 * this.length, 3 * this.height, this.length, this.height);
+                AL.ctx.strokeRect(3 * this.length, 3 * this.height, this.length, this.height);
+                AL.ctx.fillRect(3 * this.length, 3 * this.height, this.length, this.height);
                 this.setupDrawingStyles();
             }
 
             if (this.stagger === 21) {
-                this.ctx.strokeRect(2 * this.length, 3 * this.height, this.length, this.height);
-                this.ctx.fillRect(2 * this.length, 3 * this.height, this.length, this.height);
+                AL.ctx.strokeRect(2 * this.length, 3 * this.height, this.length, this.height);
+                AL.ctx.fillRect(2 * this.length, 3 * this.height, this.length, this.height);
                 this.setupDrawingStyles();
             }
 
             if (this.stagger === 22) {
-                this.ctx.strokeRect(this.length, 3 * this.height, this.length, this.height);
-                this.ctx.fillRect(this.length, 3 * this.height, this.length, this.height);
+                AL.ctx.strokeRect(this.length, 3 * this.height, this.length, this.height);
+                AL.ctx.fillRect(this.length, 3 * this.height, this.length, this.height);
                 this.setupDrawingStyles();
             }
 
             if (this.stagger === 23) {
-                this.ctx.strokeRect(0, 3 * this.height, this.length, this.height);
-                this.ctx.fillRect(0, 3 * this.height, this.length, this.height);
+                AL.ctx.strokeRect(0, 3 * this.height, this.length, this.height);
+                AL.ctx.fillRect(0, 3 * this.height, this.length, this.height);
                 this.setupDrawingStyles();
             }
 
             if (this.stagger === 24) {
-                this.ctx.strokeRect(0, 4 * this.height, this.length, this.height);
-                this.ctx.fillRect(0, 4 * this.height, this.length, this.height);
+                AL.ctx.strokeRect(0, 4 * this.height, this.length, this.height);
+                AL.ctx.fillRect(0, 4 * this.height, this.length, this.height);
                 this.setupDrawingStyles();
             }
 
             if (this.stagger === 25) {
-                this.ctx.strokeRect(this.length, 4 * this.height, this.length, this.height);
-                this.ctx.fillRect(this.length, 4 * this.height, this.length, this.height);
+                AL.ctx.strokeRect(this.length, 4 * this.height, this.length, this.height);
+                AL.ctx.fillRect(this.length, 4 * this.height, this.length, this.height);
                 this.setupDrawingStyles();
             }
 
             if (this.stagger === 26) {
-                this.ctx.strokeRect(2 * this.length, 4 * this.height, this.length, this.height);
-                this.ctx.fillRect(2 * this.length, 4 * this.height, this.length, this.height);
+                AL.ctx.strokeRect(2 * this.length, 4 * this.height, this.length, this.height);
+                AL.ctx.fillRect(2 * this.length, 4 * this.height, this.length, this.height);
                 this.setupDrawingStyles();
             }
 
             if (this.stagger === 27) {
-                this.ctx.strokeRect(3 * this.length, 4 * this.height, this.length, this.height);
-                this.ctx.fillRect(3 * this.length, 4 * this.height, this.length, this.height);
+                AL.ctx.strokeRect(3 * this.length, 4 * this.height, this.length, this.height);
+                AL.ctx.fillRect(3 * this.length, 4 * this.height, this.length, this.height);
                 this.setupDrawingStyles();
             }
 
             if (this.stagger === 28) {
-                this.ctx.strokeRect(4 * this.length, 4 * this.height, this.length, this.height);
-                this.ctx.fillRect(4 * this.length, 4 * this.height, this.length, this.height);
+                AL.ctx.strokeRect(4 * this.length, 4 * this.height, this.length, this.height);
+                AL.ctx.fillRect(4 * this.length, 4 * this.height, this.length, this.height);
                 this.setupDrawingStyles();
             }
 
             if (this.stagger === 29) {
-                this.ctx.strokeRect(5 * this.length, 4 * this.height, this.length, this.height);
-                this.ctx.fillRect(5 * this.length, 4 * this.height, this.length, this.height);
+                AL.ctx.strokeRect(5 * this.length, 4 * this.height, this.length, this.height);
+                AL.ctx.fillRect(5 * this.length, 4 * this.height, this.length, this.height);
                 this.setupDrawingStyles();
             }
         }
@@ -225,17 +225,17 @@ export default class StainedGlass extends AL {
 
             this.rotateCanvasDegrees(this.random2);
 
-            this.ctx.globalCompositeOperation = AL.pickRandomElement(this.modes);
+            AL.ctx.globalCompositeOperation = AL.pickRandomElement(this.modes);
 
-            this.ctx.fillRect(
-                this.w / 2 - this.random1 * this.length,
-                this.h / 2 - this.height * 1.5,
+            AL.ctx.fillRect(
+                AL.w / 2 - this.random1 * this.length,
+                AL.h / 2 - this.height * 1.5,
                 this.random1 * 2 * this.length,
                 3 * this.height,
             );
-            this.ctx.strokeRect(
-                this.w / 2 - this.random1 * this.length,
-                this.h / 2 - this.height * 2.5,
+            AL.ctx.strokeRect(
+                AL.w / 2 - this.random1 * this.length,
+                AL.h / 2 - this.height * 2.5,
                 this.random1 * 2 * this.length,
                 5 * this.height,
             );

--- a/src/algos/Starbursts.js
+++ b/src/algos/Starbursts.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Starbursts extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Starbursts';
 
@@ -13,7 +13,7 @@ export default class Starbursts extends AL {
     }
 
     initializeProperties() {
-        this.length = AL.random(50, Math.min(this.w, this.h) / 1.5);
+        this.length = AL.random(50, Math.min(AL.w, AL.h) / 1.5);
         this.startAngle = AL.random(0, 100);
         this.endAngle = AL.random(101, 360);
         this.rotate = AL.random(1, 6);
@@ -23,8 +23,8 @@ export default class Starbursts extends AL {
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = AL.randomColor(5, 255, 0.8, 0.8);
-        this.ctx.fillStyle = AL.randomColor(5, 255, 0.1, 0.1);
+        AL.ctx.strokeStyle = AL.randomColor(5, 255, 0.8, 0.8);
+        AL.ctx.fillStyle = AL.randomColor(5, 255, 0.1, 0.1);
     }
 
     draw() {
@@ -32,9 +32,9 @@ export default class Starbursts extends AL {
             this.stagger %= 3;
 
             if (this.stagger === 0) {
-                this.ctx.arc(
-                    this.w / 2,
-                    this.h / 2 - this.length,
+                AL.ctx.arc(
+                    AL.w / 2,
+                    AL.h / 2 - this.length,
                     this.maxGap / 2,
                     this.startAngle,
                     this.endAngle,
@@ -42,22 +42,22 @@ export default class Starbursts extends AL {
             }
 
             if (this.stagger === 1) {
-                this.ctx.lineTo(this.w / 2 + this.length, this.h / 2 - this.length);
+                AL.ctx.lineTo(AL.w / 2 + this.length, AL.h / 2 - this.length);
             }
 
             if (this.stagger === 2) {
-                this.ctx.beginPath();
-                this.ctx.arc(
-                    this.w / 2 + this.length,
-                    this.h / 2 - 2 * this.length,
+                AL.ctx.beginPath();
+                AL.ctx.arc(
+                    AL.w / 2 + this.length,
+                    AL.h / 2 - 2 * this.length,
                     this.maxGap,
                     this.startAngle,
                     this.endAngle,
                 );
-                this.ctx.fill();
+                AL.ctx.fill();
             }
 
-            this.ctx.stroke();
+            AL.ctx.stroke();
             this.rotateCanvasRadians(this.rotate);
 
             this.length -= this.gap;
@@ -74,11 +74,11 @@ export default class Starbursts extends AL {
         this.t += 1;
 
         if (this.t % (this.speed * 420) === 0) {
-            this.ctx.closePath();
-            this.ctx.beginPath();
+            AL.ctx.closePath();
+            AL.ctx.beginPath();
             this.setupDrawingStyles();
             if (Math.random() < 0.15) {
-                this.ctx.fillStyle = 'rgb(0,0,0)';
+                AL.ctx.fillStyle = 'rgb(0,0,0)';
             }
             this.rotateCanvasRadians(Math.random() * Math.PI);
         }

--- a/src/algos/Starship.js
+++ b/src/algos/Starship.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Starship extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Starship';
 
@@ -26,13 +26,13 @@ export default class Starship extends AL {
     }
 
     setupConstantStyles() {
-        this.ctx.shadowBlur = 2;
-        this.ctx.lineWidth = 0.5;
-        this.ctx.globalCompositeOperation = 'hard-light';
+        AL.ctx.shadowBlur = 2;
+        AL.ctx.lineWidth = 0.5;
+        AL.ctx.globalCompositeOperation = 'hard-light';
     }
 
     setupDrawingStyles() {
-        this.ctx.shadowColor = this.ctx.strokeStyle = AL.randomColor(0, 255, 0.6, 1);
+        AL.ctx.shadowColor = AL.ctx.strokeStyle = AL.randomColor(0, 255, 0.6, 1);
     }
 
     draw() {
@@ -41,7 +41,7 @@ export default class Starship extends AL {
             this.seq.push(radius);
             this.seq.shift();
 
-            if (radius > Math.max(this.w, this.h)) {
+            if (radius > Math.max(AL.w, AL.h)) {
                 this.first += 1;
                 this.second += 1;
                 this.seq = [this.first, this.second];
@@ -49,8 +49,8 @@ export default class Starship extends AL {
                 this.rotateCanvasRadians(Math.PI / this.divisor);
             }
 
-            this.ctx.arc(this.w / 2, this.h / 2, radius, 0, 2 * Math.PI);
-            this.ctx.stroke();
+            AL.ctx.arc(AL.w / 2, AL.h / 2, radius, 0, 2 * Math.PI);
+            AL.ctx.stroke();
         }
 
         this.t += 1;
@@ -58,7 +58,7 @@ export default class Starship extends AL {
         if (this.t % (this.speed * 240) === 0) {
             this.initializeProperties();
             this.setupDrawingStyles();
-            this.ctx.beginPath();
+            AL.ctx.beginPath();
         }
 
         if (this.t % (this.speed * 1200) === 0) {

--- a/src/algos/Subwoofer.js
+++ b/src/algos/Subwoofer.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Subwoofer extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Subwoofer';
 
@@ -21,26 +21,20 @@ export default class Subwoofer extends AL {
     }
 
     setupConstantStyles() {
-        this.ctx.strokeStyle = 'white';
+        AL.ctx.strokeStyle = 'white';
     }
 
     setupDrawingStyles() {
-        this.ctx.lineWidth = AL.random(7, 70);
+        AL.ctx.lineWidth = AL.random(7, 70);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
             for (let i = 0; i < 30; i++) {
-                this.ctx.strokeStyle = this.colors[i % this.colors.length];
-                this.ctx.beginPath();
-                this.ctx.arc(
-                    this.w / 2,
-                    this.h / 2,
-                    this.size + i * this.ctx.lineWidth,
-                    0,
-                    2 * Math.PI,
-                );
-                this.ctx.stroke();
+                AL.ctx.strokeStyle = this.colors[i % this.colors.length];
+                AL.ctx.beginPath();
+                AL.ctx.arc(AL.w / 2, AL.h / 2, this.size + i * AL.ctx.lineWidth, 0, 2 * Math.PI);
+                AL.ctx.stroke();
             }
         }
 

--- a/src/algos/Supernova.js
+++ b/src/algos/Supernova.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Supernova extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Supernova';
 
@@ -20,18 +20,18 @@ export default class Supernova extends AL {
     }
 
     setupDrawingStyles() {
-        this.ctx.fillStyle = AL.randomColor(0, 255, 0.03, 0.06);
-        this.ctx.strokeStyle = AL.randomColor(0, 255, 0.06, 0.12);
+        AL.ctx.fillStyle = AL.randomColor(0, 255, 0.03, 0.06);
+        AL.ctx.strokeStyle = AL.randomColor(0, 255, 0.06, 0.12);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.translate(this.w / 2, this.h / 2);
-            this.ctx.moveTo(0, 0);
-            this.ctx.fillRect(0, 0, this.length, this.length);
-            this.ctx.strokeRect(0, 0, this.length, this.length);
-            this.ctx.rotate(1.618 * this.rotate);
-            this.ctx.translate(-this.w / 2, -this.h / 2);
+            AL.ctx.translate(AL.w / 2, AL.h / 2);
+            AL.ctx.moveTo(0, 0);
+            AL.ctx.fillRect(0, 0, this.length, this.length);
+            AL.ctx.strokeRect(0, 0, this.length, this.length);
+            AL.ctx.rotate(1.618 * this.rotate);
+            AL.ctx.translate(-AL.w / 2, -AL.h / 2);
         }
 
         if (this.t % (this.speed * this.approach) === 0) {
@@ -39,7 +39,7 @@ export default class Supernova extends AL {
             this.length = this.fib.at(-2) + this.fib.at(-1) + 3;
         }
 
-        if (this.length > Math.max(this.w, this.h)) {
+        if (this.length > Math.max(AL.w, AL.h)) {
             this.length = 0;
             this.approach = AL.random(5, 31);
             this.fib = [0, Number(Math.random().toFixed(3))];

--- a/src/algos/Sushi.js
+++ b/src/algos/Sushi.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Sushi extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Sushi';
 
@@ -16,34 +16,34 @@ export default class Sushi extends AL {
     initializeProperties() {
         this.gap = 4;
         this.radius = 40;
-        this.rows = Math.round(this.h / (this.radius + this.gap));
-        this.cols = Math.round(this.w / (this.radius + this.gap));
+        this.rows = Math.round(AL.h / (this.radius + this.gap));
+        this.cols = Math.round(AL.w / (this.radius + this.gap));
     }
 
     setupConstantStyles() {
-        this.ctx.strokeStyle = 'white';
-        this.ctx.globalCompositeOperation = 'difference';
+        AL.ctx.strokeStyle = 'white';
+        AL.ctx.globalCompositeOperation = 'difference';
     }
 
     setupDrawingStyles() {
-        this.ctx.lineWidth = AL.random(3, 17);
-        this.ctx.fillStyle = AL.randomColor();
+        AL.ctx.lineWidth = AL.random(3, 17);
+        AL.ctx.fillStyle = AL.randomColor();
     }
 
     draw() {
         if (this.t % this.speed === 0) {
             for (let i = 0; i <= this.rows; i++) {
                 for (let j = 0; j <= this.cols; j++) {
-                    this.ctx.beginPath();
-                    this.ctx.arc(
+                    AL.ctx.beginPath();
+                    AL.ctx.arc(
                         100 * j - 50,
                         100 * i - 50,
                         this.radius,
                         Math.random(),
                         Math.random() * 2 * Math.PI,
                     );
-                    this.ctx.stroke();
-                    this.ctx.fill();
+                    AL.ctx.stroke();
+                    AL.ctx.fill();
                 }
             }
         }

--- a/src/algos/Swirls.js
+++ b/src/algos/Swirls.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Swirls extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Swirls';
 
@@ -13,12 +13,12 @@ export default class Swirls extends AL {
     }
 
     initializeProperties() {
-        this.x1 = AL.random(0, this.w);
-        this.y1 = AL.random(0, this.h);
-        this.x2 = AL.random(0, this.w);
-        this.y2 = AL.random(0, this.h);
-        this.x3 = AL.random(0, this.w);
-        this.y3 = AL.random(0, this.h);
+        this.x1 = AL.random(0, AL.w);
+        this.y1 = AL.random(0, AL.h);
+        this.x2 = AL.random(0, AL.w);
+        this.y2 = AL.random(0, AL.h);
+        this.x3 = AL.random(0, AL.w);
+        this.y3 = AL.random(0, AL.h);
         this.rotate = AL.random(1, 10);
         this.numColors = 7;
         this.colors = AL.generateHSLAPalette(this.numColors, 'hue');
@@ -26,18 +26,18 @@ export default class Swirls extends AL {
     }
 
     setupConstantStyles() {
-        this.ctx.lineWidth = 2;
-        this.ctx.shadowColor = 'rgba(5, 5, 5, 0.7)';
-        this.ctx.shadowBlur = 3;
+        AL.ctx.lineWidth = 2;
+        AL.ctx.shadowColor = 'rgba(5, 5, 5, 0.7)';
+        AL.ctx.shadowBlur = 3;
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.moveTo(this.x3, this.y3);
-            this.ctx.quadraticCurveTo(this.x2, this.y2, this.x1, this.y1);
-            this.ctx.stroke();
+            AL.ctx.moveTo(this.x3, this.y3);
+            AL.ctx.quadraticCurveTo(this.x2, this.y2, this.x1, this.y1);
+            AL.ctx.stroke();
 
-            this.ctx.strokeStyle = this.colors[this.colorIndex];
+            AL.ctx.strokeStyle = this.colors[this.colorIndex];
             this.colorIndex = (this.colorIndex + 1) % this.colors.length;
 
             this.rotateCanvasRadians(this.rotate);
@@ -46,9 +46,9 @@ export default class Swirls extends AL {
         this.t += 1;
 
         if (this.t % (this.speed * 240) === 0) {
-            this.ctx.closePath();
+            AL.ctx.closePath();
             this.initializeProperties();
-            this.ctx.beginPath();
+            AL.ctx.beginPath();
         }
 
         if (this.t % (this.speed * 600) === 0) {

--- a/src/algos/TemplateBase.js
+++ b/src/algos/TemplateBase.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class TemplateBase extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'TemplateBase';
 
@@ -14,19 +14,19 @@ export default class TemplateBase extends AL {
 
     initializeProperties() {
         this.rotation = AL.random(1, 100);
-        this.x = AL.random(0, this.w);
-        this.y = AL.random(0, this.h);
+        this.x = AL.random(0, AL.w);
+        this.y = AL.random(0, AL.h);
         this.width = AL.random(10, 200);
         this.height = AL.random(10, 200);
     }
 
     setupDrawingStyles() {
-        this.ctx.fillStyle = AL.randomColor();
+        AL.ctx.fillStyle = AL.randomColor();
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.fillRect(this.x, this.y, this.width, this.height);
+            AL.ctx.fillRect(this.x, this.y, this.width, this.height);
         }
 
         this.rotateCanvasRadians(this.rotation);

--- a/src/algos/TemplateFrequency.js
+++ b/src/algos/TemplateFrequency.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class TemplateFrequency extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'TemplateFrequency';
 
@@ -20,38 +20,38 @@ export default class TemplateFrequency extends AL {
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.save();
+            AL.ctx.save();
 
             const bands = AL.frequencyAnalyser
                 ? AL.frequencyAnalyser.getBands()
                 : Array.from({ length: this.numberOfBands }, () => 0);
-            const bandWidth = this.w / this.numberOfBands;
-            const centerY = this.h / 2;
+            const bandWidth = AL.w / this.numberOfBands;
+            const centerY = AL.h / 2;
 
             const noMovement = bands.every((band) => band === 0);
 
             if (noMovement) {
                 this.rotateCanvasRadians(this.rotate * this.t * 0.0005);
-                this.ctx.fillStyle = `rgba(0, 0, 0, 0.1)`;
+                AL.ctx.fillStyle = `rgba(0, 0, 0, 0.1)`;
                 this.fillScreen();
             } else {
-                this.ctx.clearRect(0, 0, this.w, this.h);
+                AL.ctx.clearRect(0, 0, AL.w, AL.h);
             }
 
             for (let i = 0; i < this.numberOfBands; i++) {
                 const bandValue = noMovement ? Math.random() : bands[i];
-                const rectHeight = bandValue * this.h;
+                const rectHeight = bandValue * AL.h;
                 const x = i * bandWidth;
                 const y = centerY - rectHeight / 2;
                 const hue = Math.round(bandValue * 360);
 
-                this.ctx.fillStyle = `hsl(${hue} 100% 50% / ${this.alpha})`;
-                this.ctx.fillRect(x, y, bandWidth, rectHeight);
+                AL.ctx.fillStyle = `hsl(${hue} 100% 50% / ${this.alpha})`;
+                AL.ctx.fillRect(x, y, bandWidth, rectHeight);
             }
 
             this.drawWaveform();
 
-            this.ctx.restore();
+            AL.ctx.restore();
 
             if (this.t % (this.speed * 120) === 0) {
                 this.initializeProperties();
@@ -68,30 +68,30 @@ export default class TemplateFrequency extends AL {
             return;
         }
 
-        const height = Math.min(400, this.h);
-        const yOffset = this.h - height - 20;
+        const height = Math.min(400, AL.h);
+        const yOffset = AL.h - height - 20;
 
-        this.ctx.beginPath();
-        this.ctx.strokeStyle = 'white';
-        this.ctx.shadowColor = 'white';
-        this.ctx.lineWidth = 2;
-        this.ctx.shadowBlur = 10;
+        AL.ctx.beginPath();
+        AL.ctx.strokeStyle = 'white';
+        AL.ctx.shadowColor = 'white';
+        AL.ctx.lineWidth = 2;
+        AL.ctx.shadowBlur = 10;
 
-        const sliceWidth = this.w / waveformData.length;
+        const sliceWidth = AL.w / waveformData.length;
         let x = 0;
 
         for (const value of waveformData) {
             const y = yOffset + value * height;
 
             if (x === 0) {
-                this.ctx.moveTo(x, y);
+                AL.ctx.moveTo(x, y);
             } else {
-                this.ctx.lineTo(x, y);
+                AL.ctx.lineTo(x, y);
             }
 
             x += sliceWidth;
         }
 
-        this.ctx.stroke();
+        AL.ctx.stroke();
     }
 }

--- a/src/algos/TheBadge.js
+++ b/src/algos/TheBadge.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class TheBadge extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'The Badge';
 
@@ -16,7 +16,7 @@ export default class TheBadge extends AL {
     initializeProperties() {
         this.rotate = AL.random(0, 360);
         this.randCol = AL.random(0, 255);
-        this.length = AL.random(50, Math.min(this.w, this.h) / 1.5);
+        this.length = AL.random(50, Math.min(AL.w, AL.h) / 1.5);
     }
 
     setupConstantStyles() {
@@ -30,28 +30,28 @@ export default class TheBadge extends AL {
             'source-atop',
         ];
 
-        this.ctx.lineWidth = 3;
-        this.ctx.strokeStyle = 'white';
+        AL.ctx.lineWidth = 3;
+        AL.ctx.strokeStyle = 'white';
     }
 
     setupDrawingStyles() {
-        this.ctx.fillStyle = `rgb(${this.randCol + AL.random(-28, 28)},${
+        AL.ctx.fillStyle = `rgb(${this.randCol + AL.random(-28, 28)},${
             this.randCol + AL.random(-28, 28)
         },${this.randCol + AL.random(-28, 28)})`;
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.fillRect(
-                this.w / 2 - this.length * 1.5,
-                this.h / 2 - this.length * 1.5,
+            AL.ctx.fillRect(
+                AL.w / 2 - this.length * 1.5,
+                AL.h / 2 - this.length * 1.5,
                 3 * this.length,
                 3 * this.length,
             );
 
-            this.ctx.strokeRect(
-                this.w / 2 - this.length * 1.5,
-                this.h / 2 - this.length * 1.5,
+            AL.ctx.strokeRect(
+                AL.w / 2 - this.length * 1.5,
+                AL.h / 2 - this.length * 1.5,
                 3 * this.length,
                 3 * this.length,
             );
@@ -62,7 +62,7 @@ export default class TheBadge extends AL {
         this.t += 1;
 
         if (this.t % (this.speed * 25) === 0) {
-            this.length = AL.random(5, Math.min(this.w, this.h) / 3);
+            this.length = AL.random(5, Math.min(AL.w, AL.h) / 3);
             this.randCol = AL.random(0, 255);
 
             this.setupDrawingStyles();
@@ -70,7 +70,7 @@ export default class TheBadge extends AL {
 
         if (this.t % (this.speed * 50) === 0) {
             this.rotate = AL.random(0, 360);
-            this.ctx.globalCompositeOperation = AL.pickRandomElement(this.modes);
+            AL.ctx.globalCompositeOperation = AL.pickRandomElement(this.modes);
         }
 
         this.requestFrame();

--- a/src/algos/TheFan.js
+++ b/src/algos/TheFan.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class TheFan extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'The Fan';
 
@@ -15,36 +15,36 @@ export default class TheFan extends AL {
 
     initializeProperties() {
         this.rotate = AL.random(1, 359);
-        this.x1 = AL.random(0, this.w / 2);
-        this.y1 = AL.random(0, this.h / 2);
-        this.ox = AL.random(0, this.w / 2);
-        this.oy = AL.random(0, this.h / 2);
-        this.x2 = AL.random(this.w / 2, this.w);
-        this.y2 = AL.random(this.h / 2, this.h);
-        this.dx = AL.random(this.w / 2, this.w);
-        this.dy = AL.random(this.h / 2, this.h);
+        this.x1 = AL.random(0, AL.w / 2);
+        this.y1 = AL.random(0, AL.h / 2);
+        this.ox = AL.random(0, AL.w / 2);
+        this.oy = AL.random(0, AL.h / 2);
+        this.x2 = AL.random(AL.w / 2, AL.w);
+        this.y2 = AL.random(AL.h / 2, AL.h);
+        this.dx = AL.random(AL.w / 2, AL.w);
+        this.dy = AL.random(AL.h / 2, AL.h);
     }
 
     setupConstantStyles() {
-        this.ctx.globalCompositeOperation = 'luminosity';
-        this.ctx.filter = 'saturate(500%)';
-        this.ctx.shadowColor = 'black';
-        this.ctx.shadowBlur = 4;
+        AL.ctx.globalCompositeOperation = 'luminosity';
+        AL.ctx.filter = 'saturate(500%)';
+        AL.ctx.shadowColor = 'black';
+        AL.ctx.shadowBlur = 4;
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = AL.randomColor();
+        AL.ctx.strokeStyle = AL.randomColor();
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.moveTo(this.ox, this.oy);
-            this.ctx.bezierCurveTo(this.x1, this.y1, this.x2, this.y2, this.dx, this.dy);
+            AL.ctx.moveTo(this.ox, this.oy);
+            AL.ctx.bezierCurveTo(this.x1, this.y1, this.x2, this.y2, this.dx, this.dy);
 
             this.ox += 1;
             this.dy += 1;
 
-            this.ctx.stroke();
+            AL.ctx.stroke();
         }
 
         this.t += 1;
@@ -54,7 +54,7 @@ export default class TheFan extends AL {
         if (this.t % (this.speed * 240) === 0) {
             this.initializeProperties();
             this.setupDrawingStyles();
-            this.ctx.beginPath();
+            AL.ctx.beginPath();
         }
 
         this.requestFrame();

--- a/src/algos/Thread.js
+++ b/src/algos/Thread.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Thread extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Thread';
 
@@ -14,28 +14,28 @@ export default class Thread extends AL {
     }
 
     initializeProperties() {
-        this.offset = AL.random(30, this.h * 0.75);
+        this.offset = AL.random(30, AL.h * 0.75);
         this.radius = AL.random(25, 350);
         this.rotate = AL.random(1, 35);
         this.angle = 0;
     }
 
     setupConstentProperties() {
-        this.ctx.fillStyle = 'rgba(0, 0, 0, 0.5)';
+        AL.ctx.fillStyle = 'rgba(0, 0, 0, 0.5)';
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = AL.randomColor(20, 255, 0.15, 1);
+        AL.ctx.strokeStyle = AL.randomColor(20, 255, 0.15, 1);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            const y = this.h / 2 + Math.sin(this.angle) * this.offset;
+            const y = AL.h / 2 + Math.sin(this.angle) * this.offset;
             this.angle += this.speed;
 
-            this.ctx.beginPath();
-            this.ctx.arc(this.w / 2, y, this.radius, 0, 2 * Math.PI);
-            this.ctx.stroke();
+            AL.ctx.beginPath();
+            AL.ctx.arc(AL.w / 2, y, this.radius, 0, 2 * Math.PI);
+            AL.ctx.stroke();
         }
 
         this.t += 1;

--- a/src/algos/ThreeD.js
+++ b/src/algos/ThreeD.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class ThreeD extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Three D';
 
@@ -28,13 +28,13 @@ export default class ThreeD extends AL {
     }
 
     setupDrawingStyles() {
-        this.ctx.fillStyle = AL.randomColor(0, 255, 0.5, 1);
-        this.ctx.shadowColor = 'black';
-        this.ctx.shadowOffsetX = 4;
-        this.ctx.shadowOffsetY = 4;
-        this.ctx.shadowBlur = 5;
-        this.ctx.textAlign = 'center';
-        this.ctx.font = `${this.fontSize}px sans-serif`;
+        AL.ctx.fillStyle = AL.randomColor(0, 255, 0.5, 1);
+        AL.ctx.shadowColor = 'black';
+        AL.ctx.shadowOffsetX = 4;
+        AL.ctx.shadowOffsetY = 4;
+        AL.ctx.shadowBlur = 5;
+        AL.ctx.textAlign = 'center';
+        AL.ctx.font = `${this.fontSize}px sans-serif`;
     }
 
     draw() {
@@ -42,50 +42,50 @@ export default class ThreeD extends AL {
             this.stagger %= 5;
 
             if (this.stagger === 0) {
-                this.ctx.save();
-                this.ctx.translate(this.w * 0.25, this.h * 0.25);
-                this.ctx.rotate(this.rot1);
-                this.ctx.fillText(this.letter, this.w * 0.25, 0);
-                this.ctx.translate(-this.w * 0.25, -this.h * 0.25);
-                this.ctx.restore();
+                AL.ctx.save();
+                AL.ctx.translate(AL.w * 0.25, AL.h * 0.25);
+                AL.ctx.rotate(this.rot1);
+                AL.ctx.fillText(this.letter, AL.w * 0.25, 0);
+                AL.ctx.translate(-AL.w * 0.25, -AL.h * 0.25);
+                AL.ctx.restore();
             }
 
             if (this.stagger === 1) {
-                this.ctx.save();
-                this.ctx.translate(this.w * 0.75, this.h * 0.25);
-                this.ctx.rotate(this.rot2);
-                this.ctx.fillText(this.letter, 0, this.h * 0.25);
-                this.ctx.translate(-this.w * 0.75, -this.h * 0.25);
-                this.ctx.restore();
+                AL.ctx.save();
+                AL.ctx.translate(AL.w * 0.75, AL.h * 0.25);
+                AL.ctx.rotate(this.rot2);
+                AL.ctx.fillText(this.letter, 0, AL.h * 0.25);
+                AL.ctx.translate(-AL.w * 0.75, -AL.h * 0.25);
+                AL.ctx.restore();
             }
 
             if (this.stagger === 2) {
-                this.ctx.save();
-                this.ctx.translate(this.w * 0.75, this.h * 0.75);
-                this.ctx.rotate(this.rot3);
-                this.ctx.fillText(this.letter, this.w * 0.75, 0);
-                this.ctx.translate(-this.w * 0.75, -this.h * 0.75);
-                this.ctx.restore();
+                AL.ctx.save();
+                AL.ctx.translate(AL.w * 0.75, AL.h * 0.75);
+                AL.ctx.rotate(this.rot3);
+                AL.ctx.fillText(this.letter, AL.w * 0.75, 0);
+                AL.ctx.translate(-AL.w * 0.75, -AL.h * 0.75);
+                AL.ctx.restore();
             }
 
             if (this.stagger === 3) {
-                this.ctx.save();
-                this.ctx.translate(this.w * 0.25, this.h * 0.75);
-                this.ctx.rotate(this.rot4);
-                this.ctx.fillText(this.letter, 0, this.h * 0.75);
-                this.ctx.translate(-this.w * 0.25, -this.h * 0.75);
-                this.ctx.restore();
+                AL.ctx.save();
+                AL.ctx.translate(AL.w * 0.25, AL.h * 0.75);
+                AL.ctx.rotate(this.rot4);
+                AL.ctx.fillText(this.letter, 0, AL.h * 0.75);
+                AL.ctx.translate(-AL.w * 0.25, -AL.h * 0.75);
+                AL.ctx.restore();
             }
 
             if (this.stagger === 4) {
-                this.ctx.translate(this.w / 2, this.h / 2);
-                this.ctx.rotate(this.rot5);
-                this.ctx.fillText(this.letter, 0, 0);
-                this.ctx.fillText(this.letter, this.w * 0.125, this.h * 0.125);
-                this.ctx.fillText(this.letter, this.w * 0.875, this.h * 0.125);
-                this.ctx.fillText(this.letter, this.w * 0.875, this.h * 0.875);
-                this.ctx.translate(-this.w / 2, -this.h / 2);
-                this.ctx.fillText(this.letter, this.w * 0.875, this.h * 0.125);
+                AL.ctx.translate(AL.w / 2, AL.h / 2);
+                AL.ctx.rotate(this.rot5);
+                AL.ctx.fillText(this.letter, 0, 0);
+                AL.ctx.fillText(this.letter, AL.w * 0.125, AL.h * 0.125);
+                AL.ctx.fillText(this.letter, AL.w * 0.875, AL.h * 0.125);
+                AL.ctx.fillText(this.letter, AL.w * 0.875, AL.h * 0.875);
+                AL.ctx.translate(-AL.w / 2, -AL.h / 2);
+                AL.ctx.fillText(this.letter, AL.w * 0.875, AL.h * 0.125);
             }
 
             this.stagger += 1;
@@ -96,7 +96,7 @@ export default class ThreeD extends AL {
         if (this.t % (this.speed * 75) === 0) {
             this.fontSize = AL.random(24, 80);
 
-            this.ctx.font = `${this.fontSize}px serif`;
+            AL.ctx.font = `${this.fontSize}px serif`;
         }
 
         if (this.t % (this.speed * 150) === 0) {
@@ -106,7 +106,7 @@ export default class ThreeD extends AL {
             this.rot4 = AL.random(4, 18);
             this.rot5 = AL.random(-15, -2);
 
-            this.ctx.fillStyle = AL.randomColor(0, 255, 0.5, 1);
+            AL.ctx.fillStyle = AL.randomColor(0, 255, 0.5, 1);
         }
 
         if (this.t % (this.speed * 300) === 0) {

--- a/src/algos/Trance.js
+++ b/src/algos/Trance.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Trance extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Trance';
 
@@ -22,30 +22,25 @@ export default class Trance extends AL {
         this.size = AL.random(15, 220);
         this.rotate = AL.random(1, 71);
         this.squares = AL.pickRandomElement(this.divisions);
-        this.radius = AL.random(25, Math.max(this.w, this.h) / 2);
+        this.radius = AL.random(25, Math.max(AL.w, AL.h) / 2);
     }
 
     setupDrawingStyles() {
-        this.ctx.fillStyle = AL.randomColor();
-        this.ctx.strokeStyle = AL.randomColor();
-        this.ctx.globalCompositeOperation = 'overlay';
+        AL.ctx.fillStyle = AL.randomColor();
+        AL.ctx.strokeStyle = AL.randomColor();
+        AL.ctx.globalCompositeOperation = 'overlay';
     }
 
     draw() {
         if (this.t % this.speed === 0) {
             for (let i = 0; i < this.squares; i++) {
                 this.angle = (i * Math.PI * 2) / this.squares;
-                const x = this.w / 2 + Math.cos(this.angle) * this.radius;
-                const y = this.h / 2 + Math.sin(this.angle) * this.radius;
+                const x = AL.w / 2 + Math.cos(this.angle) * this.radius;
+                const y = AL.h / 2 + Math.sin(this.angle) * this.radius;
 
-                this.ctx.beginPath();
-                this.ctx.fillRect(
-                    x - this.size / 4,
-                    y - this.size / 4,
-                    this.size / 2,
-                    this.size / 2,
-                );
-                this.ctx.strokeRect(x - this.size / 2, y - this.size / 2, this.size, this.size);
+                AL.ctx.beginPath();
+                AL.ctx.fillRect(x - this.size / 4, y - this.size / 4, this.size / 2, this.size / 2);
+                AL.ctx.strokeRect(x - this.size / 2, y - this.size / 2, this.size, this.size);
             }
         }
 
@@ -56,13 +51,13 @@ export default class Trance extends AL {
         if (this.t % (this.speed * 9) === 0) {
             this.initializeProperties();
 
-            this.ctx.globalCompositeOperation = 'overlay';
-            this.ctx.fillStyle = AL.randomColor();
+            AL.ctx.globalCompositeOperation = 'overlay';
+            AL.ctx.fillStyle = AL.randomColor();
         }
 
         if (this.t % (this.speed * 63) === 0) {
-            this.ctx.globalCompositeOperation = 'source-over';
-            this.ctx.strokeStyle = AL.randomColor();
+            AL.ctx.globalCompositeOperation = 'source-over';
+            AL.ctx.strokeStyle = AL.randomColor();
         }
 
         this.requestFrame();

--- a/src/algos/Triangulate.js
+++ b/src/algos/Triangulate.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Triangulate extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Triangulate';
 
@@ -23,34 +23,34 @@ export default class Triangulate extends AL {
         this.size = AL.random(15, 100);
         this.rotate = AL.pickRandomElement(this.rotations);
         this.triangles = AL.pickRandomElement(this.divisions);
-        this.radius = AL.random(60, Math.max(this.w, this.h) / 2);
+        this.radius = AL.random(60, Math.max(AL.w, AL.h) / 2);
     }
 
     setupDrawingStyles() {
-        this.ctx.lineWidth = 3;
-        this.ctx.strokeStyle = 'black';
-        this.ctx.fillStyle = AL.randomColor(0, 255, 0.2, 0.45);
+        AL.ctx.lineWidth = 3;
+        AL.ctx.strokeStyle = 'black';
+        AL.ctx.fillStyle = AL.randomColor(0, 255, 0.2, 0.45);
     }
 
     drawTriangle(x, y, i) {
-        this.ctx.moveTo(x, y);
-        this.ctx.beginPath();
-        this.ctx.lineTo(x + this.size + i, y + i);
-        this.ctx.lineTo(x + i, y + this.size + i);
-        this.ctx.lineTo(x, y);
-        this.ctx.closePath();
+        AL.ctx.moveTo(x, y);
+        AL.ctx.beginPath();
+        AL.ctx.lineTo(x + this.size + i, y + i);
+        AL.ctx.lineTo(x + i, y + this.size + i);
+        AL.ctx.lineTo(x, y);
+        AL.ctx.closePath();
     }
 
     draw() {
         if (this.t % this.speed === 0) {
             for (let i = 0; i < this.triangles; i++) {
                 this.angle = (i * Math.PI * 2) / this.triangles;
-                const x = this.w / 2 + Math.cos(this.angle) * this.radius;
-                const y = this.h / 2 + Math.sin(this.angle) * this.radius;
+                const x = AL.w / 2 + Math.cos(this.angle) * this.radius;
+                const y = AL.h / 2 + Math.sin(this.angle) * this.radius;
 
                 this.drawTriangle(x, y, i);
-                this.ctx.fill();
-                this.ctx.stroke();
+                AL.ctx.fill();
+                AL.ctx.stroke();
             }
         }
 
@@ -62,9 +62,9 @@ export default class Triangulate extends AL {
             this.size = AL.random(15, 100);
             this.triangles = AL.pickRandomElement(this.divisions);
             this.angle = 0;
-            this.radius = AL.random(60, Math.max(this.w, this.h) / 2);
+            this.radius = AL.random(60, Math.max(AL.w, AL.h) / 2);
 
-            this.ctx.fillStyle = AL.randomColor(0, 255, 0.2, 0.45);
+            AL.ctx.fillStyle = AL.randomColor(0, 255, 0.2, 0.45);
         }
 
         if (this.t % (this.speed * 180) === 0) {

--- a/src/algos/Tripping.js
+++ b/src/algos/Tripping.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Tripping extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Tripping';
 
@@ -14,30 +14,30 @@ export default class Tripping extends AL {
     }
 
     initializeProperties() {
-        this.x1 = AL.random(0, this.w);
-        this.y1 = AL.random(0, this.h);
-        this.x2 = AL.random(0, this.w);
-        this.y2 = AL.random(0, this.h);
+        this.x1 = AL.random(0, AL.w);
+        this.y1 = AL.random(0, AL.h);
+        this.x2 = AL.random(0, AL.w);
+        this.y2 = AL.random(0, AL.h);
         this.rotate = AL.random(1, 360);
-        this.width = AL.random(50, this.w);
-        this.height = AL.random(50, this.h);
-        this.ul = AL.random(10, Math.max(this.w, this.h));
-        this.ur = AL.random(10, Math.max(this.w, this.h));
-        this.ll = AL.random(10, Math.max(this.w, this.h));
-        this.lr = AL.random(10, Math.max(this.w, this.h));
+        this.width = AL.random(50, AL.w);
+        this.height = AL.random(50, AL.h);
+        this.ul = AL.random(10, Math.max(AL.w, AL.h));
+        this.ur = AL.random(10, Math.max(AL.w, AL.h));
+        this.ll = AL.random(10, Math.max(AL.w, AL.h));
+        this.lr = AL.random(10, Math.max(AL.w, AL.h));
     }
 
     setupConstantStyles() {
-        this.ctx.lineWidth = 0.5;
+        AL.ctx.lineWidth = 0.5;
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = AL.randomColor(0, 255, 0.25, 0.5);
+        AL.ctx.strokeStyle = AL.randomColor(0, 255, 0.25, 0.5);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.roundRectExtra(this.x1, this.y1, this.width, this.height, {
+            AL.ctx.roundRectExtra(this.x1, this.y1, this.width, this.height, {
                 lowerLeft: this.ll,
                 lowerRight: this.lr,
                 upperLeft: this.ul,
@@ -53,7 +53,7 @@ export default class Tripping extends AL {
             this.ll += 1;
             this.lr += 1;
 
-            this.ctx.roundRectExtra(this.x2, this.y2, this.height, this.width, {
+            AL.ctx.roundRectExtra(this.x2, this.y2, this.height, this.width, {
                 lowerLeft: this.ur,
                 lowerRight: this.ul,
                 upperLeft: this.lr,
@@ -72,7 +72,7 @@ export default class Tripping extends AL {
             this.initializeProperties();
             this.setupDrawingStyles();
             this.clearScreen();
-            this.ctx.beginPath();
+            AL.ctx.beginPath();
         }
 
         this.requestFrame();

--- a/src/algos/Typobrush.js
+++ b/src/algos/Typobrush.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Typobrush extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Typobrush';
 
@@ -25,30 +25,30 @@ export default class Typobrush extends AL {
 
     initializeProperties() {
         this.size = 20;
-        this.x = AL.random(0, this.w);
-        this.y = AL.random(0, this.h);
+        this.x = AL.random(0, AL.w);
+        this.y = AL.random(0, AL.h);
         this.rotate = AL.random(1, 400);
         this.sizeIncrease = AL.random(1, 6);
     }
 
     setupConstantStyles() {
-        this.ctx.textAlign = 'center';
-        this.ctx.fillStyle = 'rgba(0, 0, 0, 0.75)';
+        AL.ctx.textAlign = 'center';
+        AL.ctx.fillStyle = 'rgba(0, 0, 0, 0.75)';
         this.strokeColors = AL.generateRGBAPalette(8);
         this.fillColors = AL.generateRGBAPalette(8);
     }
 
     setupDrawingStyles() {
-        this.ctx.font = `${this.size}px serif`;
-        this.ctx.strokeStyle = AL.pickRandomElement(this.strokeColors);
-        this.ctx.fillStyle = AL.pickRandomElement(this.fillColors);
+        AL.ctx.font = `${this.size}px serif`;
+        AL.ctx.strokeStyle = AL.pickRandomElement(this.strokeColors);
+        AL.ctx.fillStyle = AL.pickRandomElement(this.fillColors);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.strokeText(this.letter, this.x, this.y);
-            this.ctx.font = `${this.size}px serif`;
-            this.ctx.fillText(this.letter, this.x + 2, this.y - 2);
+            AL.ctx.strokeText(this.letter, this.x, this.y);
+            AL.ctx.font = `${this.size}px serif`;
+            AL.ctx.fillText(this.letter, this.x + 2, this.y - 2);
             this.size += this.sizeIncrease;
         }
 

--- a/src/algos/Ufos.js
+++ b/src/algos/Ufos.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class UFOs extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'UFOs';
 
@@ -22,13 +22,13 @@ export default class UFOs extends AL {
     }
 
     setupDrawingStyles() {
-        this.ctx.globalCompositeOperation = 'multiply';
-        this.ctx.canvas.style.background = `repeating-radial-gradient(circle at center, ${this.color1}, ${this.color2} ${this.perc2}%, ${this.color3} ${this.perc1}% ${this.repeats}px)`;
+        AL.ctx.globalCompositeOperation = 'multiply';
+        AL.ctx.canvas.style.background = `repeating-radial-gradient(circle at center, ${this.color1}, ${this.color2} ${this.perc2}%, ${this.color3} ${this.perc1}% ${this.repeats}px)`;
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.canvas.style.background = `repeating-radial-gradient(circle at center, ${
+            AL.ctx.canvas.style.background = `repeating-radial-gradient(circle at center, ${
                 this.color1
             }, ${this.color2} ${this.perc2}%, ${this.color3} ${this.perc1}% ${this.repeats}px)`;
 
@@ -40,9 +40,9 @@ export default class UFOs extends AL {
         this.t += 1;
 
         if (this.t % (this.speed * 40) === 0) {
-            this.ctx.beginPath();
+            AL.ctx.beginPath();
             this.initializeProperties();
-            this.ctx.canvas.style.background = `repeating-radial-gradient(circle at center, ${
+            AL.ctx.canvas.style.background = `repeating-radial-gradient(circle at center, ${
                 this.color1
             }, ${this.color2} ${this.perc2}%, ${this.color3} ${this.perc1}% ${this.repeats}px)`;
 

--- a/src/algos/Unfocused.js
+++ b/src/algos/Unfocused.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Unfocused extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Unfocused';
 
@@ -21,29 +21,29 @@ export default class Unfocused extends AL {
         this.radius1 = AL.random(5, 55);
         this.radius2 = AL.random(5, 55);
         this.radius3 = AL.random(5, 55);
-        this.x1 = AL.random(0, this.w);
-        this.y1 = AL.random(0, this.h);
-        this.x2 = AL.random(0, this.w);
-        this.y2 = AL.random(0, this.h);
-        this.x3 = AL.random(0, this.w);
-        this.y3 = AL.random(0, this.h);
+        this.x1 = AL.random(0, AL.w);
+        this.y1 = AL.random(0, AL.h);
+        this.x2 = AL.random(0, AL.w);
+        this.y2 = AL.random(0, AL.h);
+        this.x3 = AL.random(0, AL.w);
+        this.y3 = AL.random(0, AL.h);
     }
 
     setupDrawingStyles() {
-        this.ctx.fillStyle = AL.randomColor(10, 255, 0.1, 0.1);
+        AL.ctx.fillStyle = AL.randomColor(10, 255, 0.1, 0.1);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.beginPath();
-            this.ctx.arc(this.x1, this.y1, this.radius1, 0, 2 * Math.PI);
-            this.ctx.fill();
-            this.ctx.beginPath();
-            this.ctx.arc(this.x2, this.y2, this.radius2, 0, 2 * Math.PI);
-            this.ctx.fill();
-            this.ctx.beginPath();
-            this.ctx.arc(this.x3, this.y3, this.radius3, 0, 2 * Math.PI);
-            this.ctx.fill();
+            AL.ctx.beginPath();
+            AL.ctx.arc(this.x1, this.y1, this.radius1, 0, 2 * Math.PI);
+            AL.ctx.fill();
+            AL.ctx.beginPath();
+            AL.ctx.arc(this.x2, this.y2, this.radius2, 0, 2 * Math.PI);
+            AL.ctx.fill();
+            AL.ctx.beginPath();
+            AL.ctx.arc(this.x3, this.y3, this.radius3, 0, 2 * Math.PI);
+            AL.ctx.fill();
         }
 
         this.t += 1;
@@ -60,7 +60,7 @@ export default class Unfocused extends AL {
         }
 
         if (this.t % (this.speed * 500) === 0) {
-            this.ctx.fillStyle = 'rgba(0,0,0,0.5)';
+            AL.ctx.fillStyle = 'rgba(0,0,0,0.5)';
             this.fillScreen();
             this.setupDrawingStyles();
         }

--- a/src/algos/Universe.js
+++ b/src/algos/Universe.js
@@ -2,8 +2,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Universe extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Universe';
 
@@ -14,32 +14,32 @@ export default class Universe extends AL {
     }
 
     initializeProperties() {
-        this.side1 = AL.random(20, this.w);
-        this.side2 = AL.random(20, this.h);
-        this.side3 = AL.random(20, this.w);
-        this.side4 = AL.random(20, this.h);
-        this.side5 = AL.random(20, this.w);
-        this.side6 = AL.random(20, this.h);
-        this.side7 = AL.random(20, this.w);
-        this.side8 = AL.random(20, this.h);
+        this.side1 = AL.random(20, AL.w);
+        this.side2 = AL.random(20, AL.h);
+        this.side3 = AL.random(20, AL.w);
+        this.side4 = AL.random(20, AL.h);
+        this.side5 = AL.random(20, AL.w);
+        this.side6 = AL.random(20, AL.h);
+        this.side7 = AL.random(20, AL.w);
+        this.side8 = AL.random(20, AL.h);
         this.rounded1 = AL.random(5, 250);
         this.rounded2 = AL.random(5, 250);
         this.rounded3 = AL.random(5, 250);
         this.rounded4 = AL.random(5, 250);
-        this.x1 = AL.random(0, this.w);
-        this.y1 = AL.random(0, this.h);
-        this.x2 = AL.random(0, this.w);
-        this.y2 = AL.random(0, this.h);
-        this.x3 = AL.random(0, this.w);
-        this.y3 = AL.random(0, this.h);
-        this.x4 = AL.random(0, this.w);
-        this.y4 = AL.random(0, this.h);
+        this.x1 = AL.random(0, AL.w);
+        this.y1 = AL.random(0, AL.h);
+        this.x2 = AL.random(0, AL.w);
+        this.y2 = AL.random(0, AL.h);
+        this.x3 = AL.random(0, AL.w);
+        this.y3 = AL.random(0, AL.h);
+        this.x4 = AL.random(0, AL.w);
+        this.y4 = AL.random(0, AL.h);
         this.rotate = AL.random(1, 11);
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = AL.randomColor(0, 255, 0.5, 1);
-        this.ctx.fillStyle = AL.randomColor(0, 255, 0.01, 0.05);
+        AL.ctx.strokeStyle = AL.randomColor(0, 255, 0.5, 1);
+        AL.ctx.fillStyle = AL.randomColor(0, 255, 0.01, 0.05);
     }
 
     draw() {
@@ -47,7 +47,7 @@ export default class Universe extends AL {
             this.stagger %= 4;
 
             if (this.stagger === 0) {
-                this.ctx.roundRectExtra(
+                AL.ctx.roundRectExtra(
                     this.x1++,
                     this.y1++,
                     this.side1++,
@@ -64,7 +64,7 @@ export default class Universe extends AL {
             }
 
             if (this.stagger === 1) {
-                this.ctx.roundRectExtra(
+                AL.ctx.roundRectExtra(
                     this.x2--,
                     this.y2--,
                     this.side3--,
@@ -81,7 +81,7 @@ export default class Universe extends AL {
             }
 
             if (this.stagger === 2) {
-                this.ctx.roundRectExtra(
+                AL.ctx.roundRectExtra(
                     this.x3++,
                     this.y3++,
                     this.side5++,
@@ -98,7 +98,7 @@ export default class Universe extends AL {
             }
 
             if (this.stagger === 3) {
-                this.ctx.roundRectExtra(
+                AL.ctx.roundRectExtra(
                     this.x4,
                     this.y4,
                     this.side7,

--- a/src/algos/Upholstery.js
+++ b/src/algos/Upholstery.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Upholstery extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Upholstery';
 
@@ -18,26 +18,26 @@ export default class Upholstery extends AL {
         this.dash3 = AL.random(1, 50);
         this.dash2 = AL.random(20, 40);
         this.rotate = AL.random(1, 55);
-        this.x1 = AL.random(0, this.w);
-        this.y1 = AL.random(0, this.h);
-        this.x2 = AL.random(0, this.w);
-        this.y2 = AL.random(0, this.h);
+        this.x1 = AL.random(0, AL.w);
+        this.y1 = AL.random(0, AL.h);
+        this.x2 = AL.random(0, AL.w);
+        this.y2 = AL.random(0, AL.h);
     }
 
     setupConstantStyles() {
-        this.ctx.globalCompositeOperation = 'overlay';
+        AL.ctx.globalCompositeOperation = 'overlay';
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = AL.randomColor(50, 255, 1, 1);
-        this.ctx.setLineDash([this.dash1, this.dash2, this.dash3]);
+        AL.ctx.strokeStyle = AL.randomColor(50, 255, 1, 1);
+        AL.ctx.setLineDash([this.dash1, this.dash2, this.dash3]);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.moveTo(this.x1, this.y1);
-            this.ctx.lineTo(this.x2, this.y2);
-            this.ctx.stroke();
+            AL.ctx.moveTo(this.x1, this.y1);
+            AL.ctx.lineTo(this.x2, this.y2);
+            AL.ctx.stroke();
         }
 
         this.t += 1;
@@ -47,7 +47,7 @@ export default class Upholstery extends AL {
         if (this.t % (this.speed * 120) === 0) {
             this.initializeProperties();
             this.setupDrawingStyles();
-            this.ctx.beginPath();
+            AL.ctx.beginPath();
         }
 
         this.requestFrame();

--- a/src/algos/VanishingPoint.js
+++ b/src/algos/VanishingPoint.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class VanishingPoint extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Vanishing Point';
 
@@ -14,7 +14,7 @@ export default class VanishingPoint extends AL {
     }
 
     initializeBaseProperties() {
-        this.size = Math.min(this.w, this.h);
+        this.size = Math.min(AL.w, AL.h);
         this.decrease = AL.random(2, 11);
         this.timer = null;
     }
@@ -29,13 +29,13 @@ export default class VanishingPoint extends AL {
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = 'black';
+        AL.ctx.strokeStyle = 'black';
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.fillStyle = AL.pickRandomElement(this.colors);
-            this.drawTriangle(this.w / 2, this.h / 2);
+            AL.ctx.fillStyle = AL.pickRandomElement(this.colors);
+            this.drawTriangle(AL.w / 2, AL.h / 2);
 
             this.size -= this.decrease;
             if (this.size - this.decrease <= 1) {
@@ -45,7 +45,7 @@ export default class VanishingPoint extends AL {
                 this.initializeProperties();
 
                 this.timer = setTimeout(() => {
-                    this.size = Math.min(this.w, this.h);
+                    this.size = Math.min(AL.w, AL.h);
                     this.decrease = AL.random(2, 11);
                 }, 3500);
             }
@@ -64,13 +64,13 @@ export default class VanishingPoint extends AL {
     }
 
     drawTriangle = (x, y) => {
-        this.ctx.moveTo(x, y);
-        this.ctx.beginPath();
-        this.ctx.lineTo(x + this.size, y);
-        this.ctx.lineTo(x, y + this.size);
-        this.ctx.lineTo(x, y);
-        this.ctx.closePath();
-        this.ctx.fill();
-        this.ctx.stroke();
+        AL.ctx.moveTo(x, y);
+        AL.ctx.beginPath();
+        AL.ctx.lineTo(x + this.size, y);
+        AL.ctx.lineTo(x, y + this.size);
+        AL.ctx.lineTo(x, y);
+        AL.ctx.closePath();
+        AL.ctx.fill();
+        AL.ctx.stroke();
     };
 }

--- a/src/algos/VanishingRays.js
+++ b/src/algos/VanishingRays.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class VanishingRays extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Vanishing Rays';
 
@@ -31,18 +31,18 @@ export default class VanishingRays extends AL {
     }
 
     setupDrawingStyles() {
-        this.ctx.fillStyle = AL.randomColor(50, 200, 0.0025, 0.0025);
-        this.ctx.strokeStyle = AL.randomColor(0, 255, 0.8, 0.8);
-        this.ctx.font = `bold ${this.fontSize}px sans-serif`;
+        AL.ctx.fillStyle = AL.randomColor(50, 200, 0.0025, 0.0025);
+        AL.ctx.strokeStyle = AL.randomColor(0, 255, 0.8, 0.8);
+        AL.ctx.font = `bold ${this.fontSize}px sans-serif`;
     }
 
     draw() {
         if (this.t % this.speed === 0) {
             if (this.t % 6 === 0) {
-                this.ctx.fillRect(0, 0, this.w, this.h);
+                AL.ctx.fillRect(0, 0, AL.w, AL.h);
             }
 
-            this.ctx.strokeText(this.letter.repeat(15), this.w / 2, this.h / 2);
+            AL.ctx.strokeText(this.letter.repeat(15), AL.w / 2, AL.h / 2);
 
             this.rotateCanvasDegrees(this.rotate * this.angle);
         }
@@ -50,19 +50,14 @@ export default class VanishingRays extends AL {
         this.t += 1;
 
         if (this.t % (this.speed * (1440 / this.rotate)) === 0) {
-            this.ctx.strokeStyle = AL.randomColor(0, 255, 0.8, 0.8);
+            AL.ctx.strokeStyle = AL.randomColor(0, 255, 0.8, 0.8);
             this.fontSize = AL.random(30, 500);
-            this.ctx.font = `bold ${this.fontSize}px sans-serif`;
+            AL.ctx.font = `bold ${this.fontSize}px sans-serif`;
             this.angle *= -1;
         }
 
         if (this.t % (this.speed * 360) === 0) {
-            this.ctx.fillStyle = AL.randomColor(
-                0,
-                255,
-                0.006 + this.incAlpha,
-                0.006 + this.incAlpha,
-            );
+            AL.ctx.fillStyle = AL.randomColor(0, 255, 0.006 + this.incAlpha, 0.006 + this.incAlpha);
             this.incAlpha += 0.002;
         }
 

--- a/src/algos/Veils.js
+++ b/src/algos/Veils.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Veils extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Veils';
 
@@ -25,26 +25,26 @@ export default class Veils extends AL {
     initializeProperties() {
         this.letter = String.fromCodePoint(AL.pickRandomElement(this.letters));
 
-        this.x = AL.random(0, this.w);
-        this.y = AL.random(0, this.h);
+        this.x = AL.random(0, AL.w);
+        this.y = AL.random(0, AL.h);
         this.size = AL.random(30, 400);
     }
 
     setupConstantStyles() {
-        this.ctx.textAlign = 'center';
+        AL.ctx.textAlign = 'center';
     }
 
     setupDrawingStyles() {
-        this.ctx.font = `${this.size}px serif`;
-        this.ctx.strokeStyle = AL.randomColor(0, 255, 0.5, 0.5);
+        AL.ctx.font = `${this.size}px serif`;
+        AL.ctx.strokeStyle = AL.randomColor(0, 255, 0.5, 0.5);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.strokeText(this.letter, this.x, this.y);
+            AL.ctx.strokeText(this.letter, this.x, this.y);
 
             this.size += 2;
-            this.ctx.font = `${this.size}px serif`;
+            AL.ctx.font = `${this.size}px serif`;
         }
 
         this.t += 1;

--- a/src/algos/Vortrix.js
+++ b/src/algos/Vortrix.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Vortrix extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Vortrix';
 
@@ -14,19 +14,19 @@ export default class Vortrix extends AL {
     }
 
     initializeProperties() {
-        this.x = AL.random(0, this.w);
-        this.y = AL.random(0, this.h);
+        this.x = AL.random(0, AL.w);
+        this.y = AL.random(0, AL.h);
         this.size = AL.random(60, 400);
         this.rotate = AL.random(1, 60);
     }
 
     setupConstantStyles() {
-        this.ctx.shadowBlur = 10;
-        this.ctx.fillStyle = 'rgba(0, 0, 0, 0.75)';
+        AL.ctx.shadowBlur = 10;
+        AL.ctx.fillStyle = 'rgba(0, 0, 0, 0.75)';
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = this.ctx.shadowColor = AL.randomColor(0, 255, 0.5, 1);
+        AL.ctx.strokeStyle = AL.ctx.shadowColor = AL.randomColor(0, 255, 0.5, 1);
     }
 
     draw() {
@@ -48,13 +48,13 @@ export default class Vortrix extends AL {
     }
 
     drawTriangle(x, y) {
-        this.ctx.moveTo(x, y);
-        this.ctx.beginPath();
-        this.ctx.lineTo(x + this.size, y);
-        this.ctx.lineTo(x, y + this.size);
-        this.ctx.lineTo(x, y);
-        this.ctx.closePath();
-        this.ctx.fill();
-        this.ctx.stroke();
+        AL.ctx.moveTo(x, y);
+        AL.ctx.beginPath();
+        AL.ctx.lineTo(x + this.size, y);
+        AL.ctx.lineTo(x, y + this.size);
+        AL.ctx.lineTo(x, y);
+        AL.ctx.closePath();
+        AL.ctx.fill();
+        AL.ctx.stroke();
     }
 }

--- a/src/algos/Wallpapering.js
+++ b/src/algos/Wallpapering.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Wallpapering extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Wallpapering';
 
@@ -40,28 +40,28 @@ export default class Wallpapering extends AL {
     }
 
     setupDrawingStyles() {
-        this.ctx.lineWidth = 3;
-        this.ctx.strokeStyle = 'black';
-        this.ctx.globalCompositeOperation = 'overlay';
+        AL.ctx.lineWidth = 3;
+        AL.ctx.strokeStyle = 'black';
+        AL.ctx.globalCompositeOperation = 'overlay';
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.strokeRect(this.x, this.y, this.size, this.size);
-            this.ctx.fillStyle = AL.randomColor();
-            this.ctx.fillRect(this.x, this.y, this.size, this.size);
+            AL.ctx.strokeRect(this.x, this.y, this.size, this.size);
+            AL.ctx.fillStyle = AL.randomColor();
+            AL.ctx.fillRect(this.x, this.y, this.size, this.size);
 
             this.x += this.size;
-            if (this.x > this.w) {
+            if (this.x > AL.w) {
                 this.x = 0;
                 this.y += this.size;
             }
-            if (this.y > this.h) {
+            if (this.y > AL.h) {
                 this.x = 0;
                 this.y = 0;
                 this.size = AL.random(35, 200);
 
-                this.ctx.globalCompositeOperation = AL.pickRandomElement(this.modes);
+                AL.ctx.globalCompositeOperation = AL.pickRandomElement(this.modes);
             }
         }
 

--- a/src/algos/Warp2001.js
+++ b/src/algos/Warp2001.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Warp2001 extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Warp 2001';
 
@@ -24,29 +24,29 @@ export default class Warp2001 extends AL {
     }
 
     setupConstantStyles() {
-        this.ctx.shadowBlur = 3;
-        this.ctx.shadowColor = 'black';
+        AL.ctx.shadowBlur = 3;
+        AL.ctx.shadowColor = 'black';
     }
 
     setupDrawingStyles() {
-        this.ctx.lineWidth = AL.random(5, 45);
-        this.ctx.strokeStyle = AL.randomColor();
+        AL.ctx.lineWidth = AL.random(5, 45);
+        AL.ctx.strokeStyle = AL.randomColor();
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.translate(this.w / 2, this.h / 2);
-            this.ctx.moveTo(this.x, this.y);
+            AL.ctx.translate(AL.w / 2, AL.h / 2);
+            AL.ctx.moveTo(this.x, this.y);
             this.x *= 1.618;
             this.y *= 1.618;
-            if (this.x >= Math.max(this.w, this.h)) {
+            if (this.x >= Math.max(AL.w, AL.h)) {
                 this.x = 1;
                 this.y = 1;
             }
-            this.ctx.lineTo(this.x, this.y);
-            this.ctx.stroke();
-            this.ctx.rotate(this.rotate);
-            this.ctx.translate(-this.w / 2, -this.h / 2);
+            AL.ctx.lineTo(this.x, this.y);
+            AL.ctx.stroke();
+            AL.ctx.rotate(this.rotate);
+            AL.ctx.translate(-AL.w / 2, -AL.h / 2);
         }
 
         this.t += 1;
@@ -54,7 +54,7 @@ export default class Warp2001 extends AL {
         if (this.t % (this.speed * 180) === 0) {
             this.initializeProperties();
             this.setupDrawingStyles();
-            this.ctx.beginPath();
+            AL.ctx.beginPath();
         }
 
         this.requestFrame();

--- a/src/algos/Wormhole.js
+++ b/src/algos/Wormhole.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Wormhole extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Wormhole';
 
@@ -18,20 +18,20 @@ export default class Wormhole extends AL {
         this.ll = AL.random(10, 50);
         this.lr = AL.random(10, 50);
         this.rotate = AL.random(1, 44);
-        this.width = AL.random(30, this.w);
-        this.height = AL.random(30, this.h);
-        this.x = AL.random(50, this.w - 50);
-        this.y = AL.random(50, this.h - 50);
+        this.width = AL.random(30, AL.w);
+        this.height = AL.random(30, AL.h);
+        this.x = AL.random(50, AL.w - 50);
+        this.y = AL.random(50, AL.h - 50);
     }
 
     setupDrawingStyles() {
-        this.ctx.strokeStyle = AL.randomColor(0, 255, 0.2, 0.5);
-        this.ctx.fillStyle = AL.randomColor(0, 255, 0.01, 0.01);
+        AL.ctx.strokeStyle = AL.randomColor(0, 255, 0.2, 0.5);
+        AL.ctx.fillStyle = AL.randomColor(0, 255, 0.01, 0.01);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.roundRectExtra(
+            AL.ctx.roundRectExtra(
                 this.x,
                 this.y,
                 this.width,

--- a/src/algos/Wormholes.js
+++ b/src/algos/Wormholes.js
@@ -1,8 +1,8 @@
 import AL from '../AlgorithmLoader.js';
 
 export default class Wormholes extends AL {
-    constructor(ctx, w, h) {
-        super(ctx, w, h);
+    constructor() {
+        super();
 
         this.name = 'Wormholes';
 
@@ -26,33 +26,33 @@ export default class Wormholes extends AL {
     }
 
     setupDrawingStyles() {
-        this.ctx.textAlign = 'center';
-        this.ctx.font = `${this.size}px sans-serif`;
-        this.ctx.strokeStyle = 'rgba(0, 0, 0, 0.25)';
-        this.ctx.fillStyle = AL.randomColor(0, 255, 0.05, 0.15);
+        AL.ctx.textAlign = 'center';
+        AL.ctx.font = `${this.size}px sans-serif`;
+        AL.ctx.strokeStyle = 'rgba(0, 0, 0, 0.25)';
+        AL.ctx.fillStyle = AL.randomColor(0, 255, 0.05, 0.15);
     }
 
     draw() {
         if (this.t % this.speed === 0) {
-            this.ctx.fillText(this.letter, this.w / 2, this.h / 2);
-            this.ctx.strokeText(this.letter, this.w / 2, this.h / 2);
+            AL.ctx.fillText(this.letter, AL.w / 2, AL.h / 2);
+            AL.ctx.strokeText(this.letter, AL.w / 2, AL.h / 2);
         }
 
         this.size += this.change;
-        this.ctx.font = `${this.size}px sans-serif`;
+        AL.ctx.font = `${this.size}px sans-serif`;
 
-        if (this.ctx.measureText(this.letter).width > this.w / 2) {
+        if (AL.ctx.measureText(this.letter).width > AL.w / 2) {
             this.change *= -1;
         }
-        if (this.ctx.measureText(this.letter).width < 5) {
+        if (AL.ctx.measureText(this.letter).width < 5) {
             this.change *= -1;
             this.rotate = AL.random(1, 22);
             this.letter = String.fromCodePoint(AL.pickRandomElement(this.letters));
 
-            this.ctx.fillStyle = 'rgba(0, 0, 0, 0.5)';
+            AL.ctx.fillStyle = 'rgba(0, 0, 0, 0.5)';
             this.fillScreen();
 
-            this.ctx.fillStyle = AL.randomColor(0, 255, 0.05, 0.15);
+            AL.ctx.fillStyle = AL.randomColor(0, 255, 0.05, 0.15);
         }
 
         this.t += 1;


### PR DESCRIPTION
## Changes

- Add static properties ctx, w, h to AlgorithmLoader (following existing pattern for frequencyAnalyser and waveformController)
- Remove constructor params from AlgorithmLoader and all 143 algorithm classes
- Replace all this.ctx/this.w/this.h references in algos with AL.ctx/AL.w/AL.h
- Update Spiral.js to set static properties after canvas init and on resize
- Update TransitionManager to use AlgorithmLoader.ctx directly
- Fix bug: canvas dimensions now auto-update on resize without needing to restart algorithm

## Issue

Closes #138

## Testing

- [x] pnpm test - 329 tests pass
- [x] pnpm lint - 0 warnings, 0 errors  
- [x] pnpm format:check - all files formatted

## Checklist

- [x] Code follows AGENTS.md conventions
- [x] CHANGELOG.md updated
- [x] Related files updated (tests)