### PR TITLE
feat: remap keyboard controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## 2026-03-08
 
+- feat: Remap keyboard controls — add music player shortcuts (P=play/pause, ←/→=prev/next, X=stop), move player visibility to M, auto/manual mode to A, and timer interval to +/- keys
+
 - fix: Move #msg element from bottom-right to bottom-center of screen — positions messages centered while keeping algorithm names at bottom-right
 
 - refactor: Move AlgorithmChooser logic into TransitionManager — removes standalone AlgorithmChooser class, adds getRandomAlgorithm() method with lastAlgos history tracking to TransitionManager; updates tests accordingly

--- a/README.md
+++ b/README.md
@@ -34,12 +34,15 @@ the visuals.
 ## How to Use It
 
 - **Space** — Switch to a random new visualization
-- **P** — Toggle the music player open/closed
+- **M** — Toggle the music player open/closed
+- **P** — Play/pause music
+- **←** / **→** — Previous/next track
+- **X** — Stop playback
 - **H** — Show the help menu with all keyboard shortcuts
 - **F** — Toggle fullscreen mode
-- **I** — Increase auto-change interval (+10s)
-- **D** — Decrease auto-change interval (-10s)
-- **M** — Toggle manual/auto mode
+- **+** — Increase auto-change interval (+10s)
+- **-** — Decrease auto-change interval (-10s)
+- **A** — Toggle manual/auto mode
 - **S** — Toggle silent mode (hides algorithm name)
 - **W** — Toggle waveform display
 

--- a/__tests__/KeyboardController.test.js
+++ b/__tests__/KeyboardController.test.js
@@ -21,7 +21,13 @@ function makeController({ isDevEnvironment = false } = {}) {
         isInManualMode: false,
     };
 
-    const musicPlayer = { togglePlayerVisibility: vi.fn() };
+    const musicPlayer = {
+        playNext: vi.fn(),
+        playPrev: vi.fn(),
+        playTrack: vi.fn(),
+        stopPlayback: vi.fn(),
+        togglePlayerVisibility: vi.fn(),
+    };
     const devModeController = { toggleDevModal: vi.fn() };
     const spiral = { toggleWaveform: vi.fn() };
 
@@ -77,9 +83,9 @@ describe('keyboardController', () => {
         controller.destroy();
     });
 
-    it('keyI increments autoChange by 10', () => {
+    it('equal key increments autoChange by 10', () => {
         const { controller, hudController, transitionManager } = makeController();
-        dispatchKeyup('KeyI');
+        dispatchKeyup('Equal');
 
         expect(transitionManager.autoChangeIntervalInSeconds).toBe(70);
         expect(hudController.displayMessage).toHaveBeenCalledWith('Auto-change: 70secs');
@@ -87,19 +93,19 @@ describe('keyboardController', () => {
         controller.destroy();
     });
 
-    it('keyI caps autoChange at 300', () => {
+    it('equal key caps autoChange at 300', () => {
         const { controller, transitionManager } = makeController();
         transitionManager.autoChangeIntervalInSeconds = 295;
-        dispatchKeyup('KeyI');
+        dispatchKeyup('Equal');
 
         expect(transitionManager.autoChangeIntervalInSeconds).toBe(300);
 
         controller.destroy();
     });
 
-    it('keyD decrements autoChange by 10', () => {
+    it('minus key decrements autoChange by 10', () => {
         const { controller, hudController, transitionManager } = makeController();
-        dispatchKeyup('KeyD');
+        dispatchKeyup('Minus');
 
         expect(transitionManager.autoChangeIntervalInSeconds).toBe(50);
         expect(hudController.displayMessage).toHaveBeenCalledWith('Auto-change: 50secs');
@@ -107,20 +113,20 @@ describe('keyboardController', () => {
         controller.destroy();
     });
 
-    it('keyD floors autoChange at 10', () => {
+    it('minus key floors autoChange at 10', () => {
         const { controller, transitionManager } = makeController();
         transitionManager.autoChangeIntervalInSeconds = 10;
-        dispatchKeyup('KeyD');
+        dispatchKeyup('Minus');
 
         expect(transitionManager.autoChangeIntervalInSeconds).toBe(10);
 
         controller.destroy();
     });
 
-    it('keyM toggles manual on and displays message', () => {
+    it('keyA toggles manual on and displays message', () => {
         const { controller, hudController, transitionManager } = makeController();
         transitionManager.isInManualMode = false;
-        dispatchKeyup('KeyM');
+        dispatchKeyup('KeyA');
 
         expect(transitionManager.isInManualMode).toBeTruthy();
         expect(hudController.displayMessage).toHaveBeenCalledWith('Manual mode');
@@ -128,10 +134,10 @@ describe('keyboardController', () => {
         controller.destroy();
     });
 
-    it('keyM toggles manual off and displays message', () => {
+    it('keyA toggles manual off and displays message', () => {
         const { controller, hudController, transitionManager } = makeController();
         transitionManager.isInManualMode = true;
-        dispatchKeyup('KeyM');
+        dispatchKeyup('KeyA');
 
         expect(transitionManager.isInManualMode).toBeFalsy();
         expect(hudController.displayMessage).toHaveBeenCalledWith('Auto mode');
@@ -165,11 +171,47 @@ describe('keyboardController', () => {
         controller.destroy();
     });
 
-    it('keyP calls musicPlayer.togglePlayerVisibility()', () => {
+    it('keyM calls musicPlayer.togglePlayerVisibility()', () => {
+        const { controller, musicPlayer } = makeController();
+        dispatchKeyup('KeyM');
+
+        expect(musicPlayer.togglePlayerVisibility).toHaveBeenCalledOnce();
+
+        controller.destroy();
+    });
+
+    it('keyP calls musicPlayer.playTrack()', () => {
         const { controller, musicPlayer } = makeController();
         dispatchKeyup('KeyP');
 
-        expect(musicPlayer.togglePlayerVisibility).toHaveBeenCalledOnce();
+        expect(musicPlayer.playTrack).toHaveBeenCalledOnce();
+
+        controller.destroy();
+    });
+
+    it('keyX calls musicPlayer.stopPlayback()', () => {
+        const { controller, musicPlayer } = makeController();
+        dispatchKeyup('KeyX');
+
+        expect(musicPlayer.stopPlayback).toHaveBeenCalledOnce();
+
+        controller.destroy();
+    });
+
+    it('arrowLeft calls musicPlayer.playPrev()', () => {
+        const { controller, musicPlayer } = makeController();
+        dispatchKeyup('ArrowLeft');
+
+        expect(musicPlayer.playPrev).toHaveBeenCalledOnce();
+
+        controller.destroy();
+    });
+
+    it('arrowRight calls musicPlayer.playNext()', () => {
+        const { controller, musicPlayer } = makeController();
+        dispatchKeyup('ArrowRight');
+
+        expect(musicPlayer.playNext).toHaveBeenCalledOnce();
 
         controller.destroy();
     });

--- a/index.html
+++ b/index.html
@@ -53,16 +53,28 @@
                         ><span class="key">F</span><span class="label">Full-screen</span></span
                     >
                     <span class="hotkey"
-                        ><span class="key">P</span><span class="label">Player</span></span
+                        ><span class="key">M</span><span class="label">Player</span></span
                     >
                     <span class="hotkey"
-                        ><span class="key">I</span><span class="label">+10s Interval</span></span
+                        ><span class="key">P</span><span class="label">Play/Pause</span></span
                     >
                     <span class="hotkey"
-                        ><span class="key">D</span><span class="label">-10s Interval</span></span
+                        ><span class="key">←</span><span class="label">Prev track</span></span
                     >
                     <span class="hotkey"
-                        ><span class="key">M</span><span class="label">Auto/Manual</span></span
+                        ><span class="key">→</span><span class="label">Next track</span></span
+                    >
+                    <span class="hotkey"
+                        ><span class="key">X</span><span class="label">Stop</span></span
+                    >
+                    <span class="hotkey"
+                        ><span class="key">+</span><span class="label">+10s Interval</span></span
+                    >
+                    <span class="hotkey"
+                        ><span class="key">-</span><span class="label">-10s Interval</span></span
+                    >
+                    <span class="hotkey"
+                        ><span class="key">A</span><span class="label">Auto/Manual</span></span
                     >
                     <span class="hotkey"
                         ><span class="key">S</span><span class="label">Silence</span></span
@@ -91,7 +103,7 @@
                     from your device. Click Add Track(s) again to append more to the playlist. Open
                     expanded playlist view to see, reorder, or remove tracks. Use the controls to
                     play, stop etc. and click on the progress bar to skip.<span class="keys">
-                        Use the P key to hide / show the player.</span
+                        Use the M key to hide / show the player.</span
                     >
                     When a track is finished the next one will play and the playlist will loop.
                 </p>
@@ -99,9 +111,9 @@
                     VISUALIZER: Spiral will do its own thing or you can
                     <span class="keys">click, touch or press space bar to create a new spiral</span
                     >. Changes algorithm every 100 seconds by default,
-                    <span class="keys">press I key to increase </span> by 10 seconds or
-                    <span class="keys">D to decrease.</span> Or press
-                    <span class="keys">M to toggle between auto-changing and manual mode. </span>
+                    <span class="keys">press + key to increase </span> by 10 seconds or
+                    <span class="keys">- to decrease.</span> Or press
+                    <span class="keys">A to toggle between auto-changing and manual mode. </span>
                     These will take effect after the next change.
                 </p>
                 <p>

--- a/index.html
+++ b/index.html
@@ -92,8 +92,7 @@
                 <p>
                     Best in
                     <span class="keys">full-screen (press F key)</span> and accompanied by your
-                    favorite music playlist. If key commands aren't working click on screen first to
-                    focus it.
+                    favorite music playlist.
                 </p>
                 <p>
                     PLAYER:
@@ -110,7 +109,7 @@
                 <p>
                     VISUALIZER: Spiral will do its own thing or you can
                     <span class="keys">click, touch or press space bar to create a new spiral</span
-                    >. Changes algorithm every 100 seconds by default,
+                    >. Changes algorithm every 60 seconds by default,
                     <span class="keys">press + key to increase </span> by 10 seconds or
                     <span class="keys">- to decrease.</span> Or press
                     <span class="keys">A to toggle between auto-changing and manual mode. </span>

--- a/src/KeyboardController.js
+++ b/src/KeyboardController.js
@@ -12,7 +12,7 @@ export default class KeyboardController {
      * @param {Object} deps Dependencies for keyboard shortcut handling.
      * @param {import('./HudController.js').default}     deps.hudController - The HUD controller for displaying messages and managing UI visibility.
      * @param {import('./TransitionManager.js').default} deps.transitionManager - The transition manager for handling algorithm changes and auto-change settings.
-     * @param {import('./MusicPlayer.js').default}       deps.musicPlayer - The music player for controlling audio playback visibility.
+     * @param {import('./MusicPlayer.js').default}       deps.musicPlayer - The music player for controlling audio playback and visibility.
      * @param {import('./DevModeController.js').default} deps.devModeController - The dev mode controller for enabling developer features.
      * @param {import('./Spiral.js').default}            deps.spiral - The spiral instance for controlling toggling the waveform display.
      */
@@ -46,15 +46,11 @@ export default class KeyboardController {
      */
     handleKeyup(e) {
         switch (e.code) {
-            // Decrease auto-change time by `transitionTimeStepInSeconds`, with a minimum of `minTransitionTimeInSeconds`
-            case 'KeyD': {
-                this.transitionManager.autoChangeIntervalInSeconds = Math.max(
-                    this.transitionManager.autoChangeIntervalInSeconds -
-                        this.transitionTimeStepInSeconds,
-                    this.minTransitionTimeInSeconds,
-                );
+            // Toggle Auto/Manual mode on/off. In manual mode, algorithms only change when the user triggers it (e.g. by pressing Space), and the auto-change timer is paused. In auto mode, algorithms change automatically based on the auto-change timer.
+            case 'KeyA': {
+                this.transitionManager.isInManualMode = !this.transitionManager.isInManualMode;
                 this.hudController.displayMessage(
-                    `Auto-change: ${this.transitionManager.autoChangeIntervalInSeconds}secs`,
+                    this.transitionManager.isInManualMode ? 'Manual mode' : 'Auto mode',
                 );
                 break;
             }
@@ -83,31 +79,15 @@ export default class KeyboardController {
                 break;
             }
 
-            // Increase auto-change time by `transitionTimeStepInSeconds`, with a maximum of `maxTransitionTimeInSeconds`
-            case 'KeyI': {
-                this.transitionManager.autoChangeIntervalInSeconds = Math.min(
-                    this.transitionManager.autoChangeIntervalInSeconds +
-                        this.transitionTimeStepInSeconds,
-                    this.maxTransitionTimeInSeconds,
-                );
-                this.hudController.displayMessage(
-                    `Auto-change: ${this.transitionManager.autoChangeIntervalInSeconds}secs`,
-                );
-                break;
-            }
-
-            // Toggle manual mode on/off. In manual mode, algorithms only change when the user triggers it (e.g. by pressing Space), and the auto-change timer is paused. In auto mode, algorithms change automatically based on the auto-change timer.
-            case 'KeyM': {
-                this.transitionManager.isInManualMode = !this.transitionManager.isInManualMode;
-                this.hudController.displayMessage(
-                    this.transitionManager.isInManualMode ? 'Manual mode' : 'Auto mode',
-                );
-                break;
-            }
-
             // Toggle the music player's visibility
-            case 'KeyP': {
+            case 'KeyM': {
                 this.musicPlayer.togglePlayerVisibility();
+                break;
+            }
+
+            // Toggle music play/pause
+            case 'KeyP': {
+                this.musicPlayer.playTrack();
                 break;
             }
 
@@ -123,6 +103,50 @@ export default class KeyboardController {
             // Toggle the waveform display on/off in the Spiral visualization
             case 'KeyW': {
                 this.spiral.toggleWaveform();
+                break;
+            }
+
+            // Stop music playback
+            case 'KeyX': {
+                this.musicPlayer.stopPlayback();
+                break;
+            }
+
+            // Skip to previous track
+            case 'ArrowLeft': {
+                this.musicPlayer.playPrev();
+                break;
+            }
+
+            // Skip to next track
+            case 'ArrowRight': {
+                this.musicPlayer.playNext();
+                break;
+            }
+
+            // Increase auto-change time by `transitionTimeStepInSeconds`, with a maximum of `maxTransitionTimeInSeconds`
+            case 'Equal': {
+                this.transitionManager.autoChangeIntervalInSeconds = Math.min(
+                    this.transitionManager.autoChangeIntervalInSeconds +
+                        this.transitionTimeStepInSeconds,
+                    this.maxTransitionTimeInSeconds,
+                );
+                this.hudController.displayMessage(
+                    `Auto-change: ${this.transitionManager.autoChangeIntervalInSeconds}secs`,
+                );
+                break;
+            }
+
+            // Decrease auto-change time by `transitionTimeStepInSeconds`, with a minimum of `minTransitionTimeInSeconds`
+            case 'Minus': {
+                this.transitionManager.autoChangeIntervalInSeconds = Math.max(
+                    this.transitionManager.autoChangeIntervalInSeconds -
+                        this.transitionTimeStepInSeconds,
+                    this.minTransitionTimeInSeconds,
+                );
+                this.hudController.displayMessage(
+                    `Auto-change: ${this.transitionManager.autoChangeIntervalInSeconds}secs`,
+                );
                 break;
             }
 

--- a/src/Spiral.js
+++ b/src/Spiral.js
@@ -195,7 +195,7 @@ export default class Spiral {
                 this.hud.displayMessage('TIP: F FOR FULLSCREEN');
             }, 20_000),
             setTimeout(() => {
-                this.hud.displayMessage('TIP: P TO VIEW/HIDE MUSIC PLAYER');
+                this.hud.displayMessage('TIP: M TO VIEW/HIDE MUSIC PLAYER');
             }, 30_000),
         ];
 

--- a/src/WaveformController.js
+++ b/src/WaveformController.js
@@ -143,6 +143,7 @@ export default class WaveformController {
 
     /**
      * Toggle the waveform display on or off.
+     * @returns {boolean} The new state of the waveform display (true for on, false for off).
      */
     toggleWaveform() {
         this.showWaveform = !this.showWaveform;
@@ -152,5 +153,7 @@ export default class WaveformController {
         } else {
             this.destroy();
         }
+
+        return this.showWaveform;
     }
 }


### PR DESCRIPTION
## Changes

- `P` now toggles play/pause (was: toggle player visibility)
- `M` now toggles player visibility (was: auto/manual mode)
- `A` now toggles auto/manual mode (new)
- `←` / `→` skip to prev/next track (new)
- `X` stops playback (new)
- `+` (`=` key, no shift needed) increases auto-change interval, replaces `I`
- `-` decreases auto-change interval, replaces `D`
- Updated help screen, help modal body text, tip message, and README to match

## Issue

Closes #136

## Testing

- [x] Tested in pnpm start
- [x] No console errors
- [x] Feature/fix works as expected

## Checklist

- [x] Code follows [AGENTS.md](AGENTS.md) conventions
- [x] CHANGELOG.md updated
- [x] Related files updated (if applicable)