### PR TITLE
feat: blocked algorithms modal

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -17,7 +17,7 @@
                 "allowTernary": true
             }
         ],
-        "eslint/max-lines-per-function": ["warn", 550],
+        "eslint/max-lines-per-function": ["warn", 630],
         "eslint/max-statements": ["warn", 130],
         "eslint/max-lines": ["warn", 810],
         "eslint/max-params": ["warn", 5],
@@ -81,6 +81,7 @@
         "import/no-relative-parent-imports": "off",
         "import/no-named-export": "off",
         "import/group-exports": "off",
+        "import/max-dependencies": ["warn", { "max": 12 }],
         "node/no-process-env": ["warn", { "allowedVariables": ["NODE_ENV"] }],
         "vitest/require-hook": "off",
         "vitest/prefer-called-times": "off",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ ALWAYS run tests after modifying code, even if you think the changes are minor. 
 
 ## Keyboard (KeyboardController.js)
 
-Space, F, I, D, M, S, H, P, E
+Space, F, A, L, M, S, H, P, W, X, E (dev only)
 
 ## Dependencies
 
@@ -73,3 +73,4 @@ Space, F, I, D, M, S, H, P, E
 - NO inline comments - if comment is needed, write it in its own line above the
   code
 - Dont use `_` prefix for private methods/props - just use normal names.
+- Dont use forEach - prefer for of or regular for loops, or a functional method like map/filter/reduce if it makes sense.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## 2026-03-09
 
+- feat: Add blocked algorithms modal — press L to open a searchable list of all 143 algorithms with checkboxes to block/unblock them; blocked algorithms are never chosen and persist across sessions via localStorage; active pool scales the recency history window proportionally (closes #122)
+
 - feat: Save and restore user preferences across sessions — player visibility, silence mode, auto-change timing, waveform, manual/auto mode, and show-tips toggle are persisted in localStorage and restored on next launch; adds "Show welcome tips on startup" checkbox in the help screen (closes #137)
 
 ## 2026-03-08

--- a/__tests__/BlockedAlgorithmsModal.test.js
+++ b/__tests__/BlockedAlgorithmsModal.test.js
@@ -1,0 +1,228 @@
+// @vitest-environment jsdom
+// oxlint-disable max-classes-per-file
+
+import BlockedAlgorithmsModal from '../src/BlockedAlgorithmsModal.js';
+
+vi.mock(import('../src/generated/algorithmRegistry.js'), () => ({
+    algorithms: [class AlgoA {}, class AlgoB {}, class AlgoC {}, class AlgoD {}, class AlgoE {}],
+}));
+
+vi.mock(import('../src/utils/BlockedAlgorithms.js'), () => ({
+    saveBlockedAlgorithms: vi.fn(),
+}));
+
+function createTransitionManager(blockedNames = []) {
+    return {
+        blockedAlgorithms: new Set(blockedNames),
+        setBlockedAlgorithms: vi.fn().mockImplementation(function setBlockedAlgorithms(names) {
+            this.blockedAlgorithms = new Set(names);
+        }),
+    };
+}
+
+describe('blockedAlgorithmsModal', () => {
+    let modal = null;
+    let tm = null;
+
+    beforeEach(() => {
+        tm = createTransitionManager();
+        modal = new BlockedAlgorithmsModal({ transitionManager: tm });
+    });
+
+    afterEach(() => {
+        modal.destroy();
+        vi.restoreAllMocks();
+    });
+
+    describe('constructor', () => {
+        it('appends the modal element to the document body', () => {
+            expect(document.querySelector('#blocked-algos-modal')).not.toBeNull();
+        });
+
+        it('starts hidden', () => {
+            expect(document.querySelector('#blocked-algos-modal').style.display).toBe('none');
+        });
+
+        it('renders one checkbox per algorithm', () => {
+            const checkboxes = document.querySelectorAll(
+                '#blocked-algos-modal input[type="checkbox"]',
+            );
+            expect(checkboxes).toHaveLength(5);
+        });
+
+        it('renders algorithms sorted alphabetically', () => {
+            const labels = [
+                ...document.querySelectorAll('#blocked-algos-modal .blocked-item input'),
+            ].map((checkbox) => checkbox.dataset.algoName);
+            const sorted = [...labels].toSorted((a, b) => a.localeCompare(b));
+            expect(labels).toStrictEqual(sorted);
+        });
+    });
+
+    describe('toggleModal()', () => {
+        it('shows the modal when it is hidden', () => {
+            modal.toggleModal();
+            expect(document.querySelector('#blocked-algos-modal').style.display).toBe('flex');
+        });
+
+        it('hides the modal when it is visible', () => {
+            modal.toggleModal();
+            modal.toggleModal();
+            expect(document.querySelector('#blocked-algos-modal').style.display).toBe('none');
+        });
+
+        it('syncs checkbox state from the blocked set on open', () => {
+            tm.blockedAlgorithms = new Set(['AlgoA', 'AlgoC']);
+            modal.toggleModal();
+
+            const checkboxes = [
+                ...document.querySelectorAll('#blocked-algos-modal input[type="checkbox"]'),
+            ];
+            const checkedNames = checkboxes
+                .filter((checkbox) => checkbox.checked)
+                .map((checkbox) => checkbox.dataset.algoName);
+
+            expect(checkedNames).toContain('AlgoA');
+            expect(checkedNames).toContain('AlgoC');
+            expect(checkedNames).not.toContain('AlgoB');
+        });
+
+        it('clears search input on open', () => {
+            modal.searchInput.value = 'foo';
+            modal.toggleModal();
+            expect(modal.searchInput.value).toBe('');
+        });
+    });
+
+    describe('updateList()', () => {
+        it('shows correct blocked count', () => {
+            tm.blockedAlgorithms = new Set(['AlgoA', 'AlgoB']);
+            modal.updateList();
+            expect(modal.countDisplay.textContent).toBe('2 / 5 blocked');
+        });
+
+        it('disables the last unblocked checkbox when at the limit', () => {
+            // Block 4 of 5 — only AlgoE remains unblocked
+            tm.blockedAlgorithms = new Set(['AlgoA', 'AlgoB', 'AlgoC', 'AlgoD']);
+            modal.updateList();
+
+            const checkboxes = [
+                ...document.querySelectorAll('#blocked-algos-modal input[type="checkbox"]'),
+            ];
+            const unchecked = checkboxes.filter((checkbox) => !checkbox.checked);
+            expect(unchecked).toHaveLength(1);
+            expect(unchecked[0].disabled).toBeTruthy();
+        });
+
+        it('re-enables checkboxes when no longer at the limit', () => {
+            tm.blockedAlgorithms = new Set(['AlgoA', 'AlgoB', 'AlgoC', 'AlgoD']);
+            modal.updateList();
+            tm.blockedAlgorithms = new Set(['AlgoA']);
+            modal.updateList();
+
+            const disabled = [
+                ...document.querySelectorAll(
+                    '#blocked-algos-modal input[type="checkbox"]:disabled',
+                ),
+            ];
+            expect(disabled).toHaveLength(0);
+        });
+    });
+
+    describe('filterList()', () => {
+        it('hides items that do not match the search query', () => {
+            modal.toggleModal();
+            modal.searchInput.value = 'algoa';
+            modal.filterList();
+
+            const visible = [
+                ...document.querySelectorAll('#blocked-algos-modal .blocked-item'),
+            ].filter((item) => item.style.display !== 'none');
+
+            expect(visible).toHaveLength(1);
+            expect(visible[0].querySelector('input').dataset.algoName).toBe('AlgoA');
+        });
+
+        it('is case-insensitive', () => {
+            modal.toggleModal();
+            modal.searchInput.value = 'ALGOB';
+            modal.filterList();
+
+            const visible = [
+                ...document.querySelectorAll('#blocked-algos-modal .blocked-item'),
+            ].filter((item) => item.style.display !== 'none');
+
+            expect(visible).toHaveLength(1);
+        });
+
+        it('shows all items when search is cleared', () => {
+            modal.toggleModal();
+            modal.searchInput.value = 'algoa';
+            modal.filterList();
+            modal.searchInput.value = '';
+            modal.filterList();
+
+            const hidden = [
+                ...document.querySelectorAll('#blocked-algos-modal .blocked-item'),
+            ].filter((item) => item.style.display === 'none');
+
+            expect(hidden).toHaveLength(0);
+        });
+    });
+
+    describe('handleCheckboxChange()', () => {
+        it('adds a newly checked algorithm to the blocked set', () => {
+            modal.toggleModal();
+            const checkbox = [
+                ...document.querySelectorAll('#blocked-algos-modal input[type="checkbox"]'),
+            ].find((cbox) => cbox.dataset.algoName === 'AlgoA');
+
+            checkbox.checked = true;
+            checkbox.dispatchEvent(new Event('change'));
+
+            expect(tm.setBlockedAlgorithms).toHaveBeenCalledWith(expect.any(Set));
+            expect(tm.blockedAlgorithms.has('AlgoA')).toBeTruthy();
+        });
+
+        it('removes an unchecked algorithm from the blocked set', () => {
+            tm.blockedAlgorithms = new Set(['AlgoA']);
+            modal.toggleModal();
+
+            const checkbox = [
+                ...document.querySelectorAll('#blocked-algos-modal input[type="checkbox"]'),
+            ].find((cbox) => cbox.dataset.algoName === 'AlgoA');
+
+            checkbox.checked = false;
+            checkbox.dispatchEvent(new Event('change'));
+
+            expect(tm.blockedAlgorithms.has('AlgoA')).toBeFalsy();
+        });
+
+        it('prevents blocking the last remaining algorithm', () => {
+            // Block 4 of 5 — only AlgoE unblocked
+            tm.blockedAlgorithms = new Set(['AlgoA', 'AlgoB', 'AlgoC', 'AlgoD']);
+            modal.toggleModal();
+
+            const lastCheckbox = [
+                ...document.querySelectorAll('#blocked-algos-modal input[type="checkbox"]'),
+            ].find((checkbox) => !checkbox.checked);
+
+            // Try to check the last unblocked algo
+            lastCheckbox.checked = true;
+            lastCheckbox.dispatchEvent(new Event('change'));
+
+            // Should be reverted and set not updated
+            expect(lastCheckbox.checked).toBeFalsy();
+            expect(tm.blockedAlgorithms.size).toBe(4);
+        });
+    });
+
+    describe('destroy()', () => {
+        it('removes the modal from the DOM', () => {
+            modal.destroy();
+            expect(document.querySelector('#blocked-algos-modal')).toBeNull();
+            // Create a replacement for afterEach cleanup
+            modal = new BlockedAlgorithmsModal({ transitionManager: tm });
+        });
+    });
+});

--- a/__tests__/KeyboardController.test.js
+++ b/__tests__/KeyboardController.test.js
@@ -31,8 +31,10 @@ function makeController({ isDevEnvironment = false } = {}) {
     };
     const devModeController = { toggleDevModal: vi.fn() };
     const spiral = { toggleWaveform: vi.fn(), waveformController: { showWaveform: false } };
+    const blockedAlgorithmsModal = { toggleModal: vi.fn() };
 
     const controller = new KeyboardController({
+        blockedAlgorithmsModal,
         devModeController,
         hudController,
         musicPlayer,
@@ -41,7 +43,15 @@ function makeController({ isDevEnvironment = false } = {}) {
     });
     controller.bind();
 
-    return { controller, devModeController, hudController, musicPlayer, spiral, transitionManager };
+    return {
+        blockedAlgorithmsModal,
+        controller,
+        devModeController,
+        hudController,
+        musicPlayer,
+        spiral,
+        transitionManager,
+    };
 }
 
 function dispatchKeyup(code) {
@@ -240,6 +250,15 @@ describe('keyboardController', () => {
         dispatchKeyup('KeyW');
 
         expect(spiral.toggleWaveform).toHaveBeenCalledOnce();
+
+        controller.destroy();
+    });
+
+    it('keyL calls blockedAlgorithmsModal.toggleModal()', () => {
+        const { blockedAlgorithmsModal, controller } = makeController();
+        dispatchKeyup('KeyL');
+
+        expect(blockedAlgorithmsModal.toggleModal).toHaveBeenCalledOnce();
 
         controller.destroy();
     });

--- a/__tests__/TransitionManager.test.js
+++ b/__tests__/TransitionManager.test.js
@@ -327,7 +327,6 @@ describe('transitionManager', () => {
 
         it('does not repeat algorithms within the history window', () => {
             const tm = new TransitionManager(createDeps());
-            tm.lastAlgosCapacity = 4;
             const picks = new Set();
             for (let i = 0; i < 5; i++) {
                 picks.add(tm.getRandomAlgorithm());
@@ -336,25 +335,89 @@ describe('transitionManager', () => {
             expect(picks.size).toBe(5);
         });
 
-        it('evicts oldest history entry when capacity is exceeded', () => {
+        it('trims history to the effective capacity before each pick', () => {
             const tm = new TransitionManager(createDeps());
-            tm.lastAlgosCapacity = 3;
+            // Mock pool has 5 algos. Set lastAlgosCapacity=2 so effectiveCapacity = floor(5*2/5) = 2.
+            tm.lastAlgosCapacity = 2;
+            // Pick 4 times — history should never grow beyond effectiveCapacity+1 = 3
+            for (let i = 0; i < 4; i++) {
+                tm.getRandomAlgorithm();
+            }
 
-            tm.lastAlgos = new Set([
-                tm.getRandomAlgorithm(),
-                tm.getRandomAlgorithm(),
-                tm.getRandomAlgorithm(),
-            ]);
-
-            tm.getRandomAlgorithm();
-
-            expect(tm.lastAlgos.size).toBe(3);
+            expect(tm.lastAlgos.size).toBeLessThanOrEqual(3);
         });
 
         it('defaults to a capacity of 50', () => {
             const tm = new TransitionManager(createDeps());
 
             expect(tm.lastAlgosCapacity).toBe(50);
+        });
+    });
+
+    describe('blocked algorithms', () => {
+        it('defaults to an empty blocked set', () => {
+            const tm = new TransitionManager(createDeps());
+
+            expect(tm.blockedAlgorithms.size).toBe(0);
+        });
+
+        it('never picks a blocked algorithm', () => {
+            const tm = new TransitionManager(createDeps());
+            // Block 4 of 5 algos; only AlgoE remains
+            tm.blockedAlgorithms = new Set(['AlgoA', 'AlgoB', 'AlgoC', 'AlgoD']);
+
+            for (let i = 0; i < 10; i++) {
+                const picked = tm.getRandomAlgorithm();
+                expect(picked.name).toBe('AlgoE');
+            }
+        });
+
+        it('scales effective capacity proportionally with active pool size', () => {
+            const tm = new TransitionManager(createDeps());
+            // lastAlgosCapacity=50, total pool in mock=5; block 3 → 2 active
+            // effectiveCapacity = floor(2 * 50/5) = floor(20) = 20 → but capped by pool size naturally
+            tm.blockedAlgorithms = new Set(['AlgoA', 'AlgoB', 'AlgoC']);
+            // With 2 active algos and lastAlgosCapacity=2: effectiveCapacity = floor(2*2/5) = 0
+            tm.lastAlgosCapacity = 2;
+
+            for (let i = 0; i < 6; i++) {
+                tm.getRandomAlgorithm();
+            }
+
+            // With effectiveCapacity=0 all entries are evicted each round; size stays at 1 after add
+            expect(tm.lastAlgos.size).toBeLessThanOrEqual(2);
+        });
+
+        it('resets lastAlgos and uses full active pool when all active algos are in history', () => {
+            const tm = new TransitionManager(createDeps());
+            // Only 2 active algos
+            tm.blockedAlgorithms = new Set(['AlgoA', 'AlgoB', 'AlgoC']);
+
+            // Find the actual classes from the registry by picking twice
+            const _first = tm.getRandomAlgorithm();
+            const _second = tm.getRandomAlgorithm();
+            // Now lastAlgos has both active algos — next pick should reset and still succeed
+            const third = tm.getRandomAlgorithm();
+
+            expect(third).toBeDefined();
+        });
+
+        it('setBlockedAlgorithms replaces the blocked set', () => {
+            const tm = new TransitionManager(createDeps());
+            tm.setBlockedAlgorithms(['AlgoA', 'AlgoB']);
+
+            expect(tm.blockedAlgorithms.has('AlgoA')).toBeTruthy();
+            expect(tm.blockedAlgorithms.has('AlgoB')).toBeTruthy();
+            expect(tm.blockedAlgorithms.size).toBe(2);
+        });
+
+        it('setBlockedAlgorithms clears previous entries', () => {
+            const tm = new TransitionManager(createDeps());
+            tm.blockedAlgorithms = new Set(['AlgoC', 'AlgoD']);
+            tm.setBlockedAlgorithms(['AlgoA']);
+
+            expect(tm.blockedAlgorithms.has('AlgoC')).toBeFalsy();
+            expect(tm.blockedAlgorithms.has('AlgoA')).toBeTruthy();
         });
     });
 });

--- a/__tests__/utils/BlockedAlgorithms.test.js
+++ b/__tests__/utils/BlockedAlgorithms.test.js
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+
+import {
+    clearBlockedAlgorithms,
+    loadBlockedAlgorithms,
+    saveBlockedAlgorithms,
+} from '../../src/utils/BlockedAlgorithms.js';
+
+const STORAGE_KEY = 'spiral:blockedAlgorithms';
+
+describe('blockedAlgorithms', () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    describe('loadBlockedAlgorithms()', () => {
+        it('returns an empty array when localStorage is empty', () => {
+            expect(loadBlockedAlgorithms()).toStrictEqual([]);
+        });
+
+        it('returns the saved array of algorithm names', () => {
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(['AlgoA', 'AlgoB']));
+            expect(loadBlockedAlgorithms()).toStrictEqual(['AlgoA', 'AlgoB']);
+        });
+
+        it('returns an empty array for corrupt JSON', () => {
+            localStorage.setItem(STORAGE_KEY, 'not-valid-json{{{');
+            expect(loadBlockedAlgorithms()).toStrictEqual([]);
+        });
+
+        it('returns an empty array when stored value is not an array', () => {
+            localStorage.setItem(STORAGE_KEY, JSON.stringify({ algo: 'AlgoA' }));
+            expect(loadBlockedAlgorithms()).toStrictEqual([]);
+        });
+
+        it('filters out non-string entries', () => {
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(['AlgoA', 42, null, 'AlgoB']));
+            expect(loadBlockedAlgorithms()).toStrictEqual(['AlgoA', 'AlgoB']);
+        });
+    });
+
+    describe('saveBlockedAlgorithms()', () => {
+        it('persists an array of algorithm names', () => {
+            saveBlockedAlgorithms(['AlgoA', 'AlgoC']);
+            expect(JSON.parse(localStorage.getItem(STORAGE_KEY))).toStrictEqual(['AlgoA', 'AlgoC']);
+        });
+
+        it('persists an empty array', () => {
+            saveBlockedAlgorithms([]);
+            expect(JSON.parse(localStorage.getItem(STORAGE_KEY))).toStrictEqual([]);
+        });
+    });
+
+    describe('clearBlockedAlgorithms()', () => {
+        it('removes the key from localStorage', () => {
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(['AlgoA']));
+            clearBlockedAlgorithms();
+            expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+        });
+
+        it('is safe to call when nothing is saved', () => {
+            expect(() => clearBlockedAlgorithms()).not.toThrow();
+        });
+    });
+
+    describe('round-trip', () => {
+        it('save then load returns the same names', () => {
+            const names = ['Abstractions', 'Wormholes', 'Spirals'];
+            saveBlockedAlgorithms(names);
+            expect(loadBlockedAlgorithms()).toStrictEqual(names);
+        });
+    });
+});

--- a/index.html
+++ b/index.html
@@ -85,6 +85,9 @@
                     <span class="hotkey"
                         ><span class="key">W</span><span class="label">Waveform</span></span
                     >
+                    <span class="hotkey"
+                        ><span class="key">L</span><span class="label">Blocked list</span></span
+                    >
                 </div>
             </div>
             <div class="text">
@@ -118,6 +121,9 @@
                 <p>
                     The algorithm name is displayed on screen when it changes.
                     <span class="keys">Press S for silence mode to toggle it on/off. </span>
+                    <span class="keys">Press L to open the blocked algorithms list</span> where you
+                    can search and toggle which algorithms are blocked. Blocked algorithms will
+                    never be chosen and are saved and restored on next launch.
                 </p>
                 <p>
                     PLAYLIST:

--- a/src/BlockedAlgorithmsModal.js
+++ b/src/BlockedAlgorithmsModal.js
@@ -1,0 +1,152 @@
+import { algorithms } from './generated/algorithmRegistry.js';
+
+/**
+ * BlockedAlgorithmsModal — modal UI for managing the blocked algorithms list.
+ *
+ * Renders a searchable, scrollable list of all algorithms with checkboxes.
+ * Checked = blocked. The last unblocked algorithm's checkbox is disabled to
+ * ensure at least one algorithm is always available.
+ *
+ * DOM is created and appended programmatically to avoid polluting index.html.
+ */
+export default class BlockedAlgorithmsModal {
+    /**
+     * @param {Object} deps - Dependencies object containing required components
+     * @param {import('./TransitionManager.js').default} deps.transitionManager - TransitionManager instance to read/update blocked algorithms
+     */
+    constructor({ transitionManager }) {
+        this.transitionManager = transitionManager;
+
+        this.sortedAlgorithms = [...algorithms].toSorted((a, b) => a.name.localeCompare(b.name));
+
+        this.modal = this.createModal();
+        document.body.append(this.modal);
+    }
+
+    /**
+     * Build the modal DOM and wire up internal event listeners.
+     * @returns {HTMLDivElement} The root modal element, not yet attached to the document.
+     * */
+    createModal() {
+        const modal = document.createElement('div');
+        modal.id = 'blocked-algos-modal';
+        modal.style.display = 'none';
+
+        const heading = document.createElement('h3');
+        heading.textContent = 'BLOCKED ALGORITHMS';
+
+        this.countDisplay = document.createElement('p');
+        this.countDisplay.className = 'blocked-count';
+
+        this.searchInput = document.createElement('input');
+        this.searchInput.type = 'text';
+        this.searchInput.placeholder = 'Filter...';
+        this.searchInput.className = 'blocked-search';
+        this.searchInput.addEventListener('input', () => this.filterList());
+
+        this.listContainer = document.createElement('div');
+        this.listContainer.className = 'blocked-list';
+
+        for (const algo of this.sortedAlgorithms) {
+            const item = document.createElement('label');
+            item.className = 'blocked-item';
+
+            const checkbox = document.createElement('input');
+            checkbox.type = 'checkbox';
+            checkbox.dataset.algoName = algo.name;
+            checkbox.addEventListener('change', (e) => this.handleCheckboxChange(e));
+
+            item.append(checkbox);
+            item.append(document.createTextNode(algo.name));
+            this.listContainer.append(item);
+        }
+
+        const closeBtn = document.createElement('button');
+        closeBtn.textContent = 'Close';
+        closeBtn.className = 'blocked-close';
+        closeBtn.addEventListener('click', () => this.toggleModal());
+
+        modal.append(heading);
+        modal.append(this.countDisplay);
+        modal.append(this.searchInput);
+        modal.append(this.listContainer);
+        modal.append(closeBtn);
+
+        return modal;
+    }
+
+    /** Show or hide the modal. Syncs list state on open. */
+    toggleModal() {
+        if (this.modal.style.display === 'none') {
+            this.updateList();
+            this.searchInput.value = '';
+            this.filterList();
+            this.modal.style.display = 'flex';
+        } else {
+            this.modal.style.display = 'none';
+        }
+    }
+
+    /**
+     * Sync all checkbox checked/disabled states from the current blocked set,
+     * and update the count display.
+     */
+    updateList() {
+        const { blockedAlgorithms } = this.transitionManager;
+        const activeCount = algorithms.length - blockedAlgorithms.size;
+        const atLimit = activeCount <= 1;
+
+        this.countDisplay.textContent = `${blockedAlgorithms.size} / ${algorithms.length} blocked`;
+
+        /** @type {NodeListOf<HTMLInputElement>} */
+        const checkboxes = this.listContainer.querySelectorAll('input[type="checkbox"]');
+        for (const checkbox of checkboxes) {
+            const name = checkbox.dataset.algoName;
+            const isBlocked = blockedAlgorithms.has(name);
+            checkbox.checked = isBlocked;
+            // Disable the checkbox for the last remaining unblocked algorithm
+            checkbox.disabled = atLimit && !isBlocked;
+            checkbox.closest('label').classList.toggle('blocked-item-last', atLimit && !isBlocked);
+        }
+    }
+
+    /** Filter visible list items by the current search input value. */
+    filterList() {
+        const query = this.searchInput.value.toLowerCase();
+        /** @type {NodeListOf<HTMLLabelElement>} */
+        const items = this.listContainer.querySelectorAll('label.blocked-item');
+        for (const item of items) {
+            const name = item.querySelector('input').dataset.algoName.toLowerCase();
+            item.style.display = name.includes(query) ? '' : 'none';
+        }
+    }
+
+    /**
+     * Handle a checkbox toggle — update the blocked set and refresh UI.
+     * @param {Event} e - The change event from the checkbox input.
+     */
+    handleCheckboxChange(e) {
+        const checkbox = /** @type {HTMLInputElement} */ (e.target);
+        const name = checkbox.dataset.algoName;
+        const { blockedAlgorithms } = this.transitionManager;
+
+        if (checkbox.checked) {
+            // Guard: never block the last remaining algorithm
+            if (blockedAlgorithms.size >= algorithms.length - 1) {
+                checkbox.checked = false;
+                return;
+            }
+            blockedAlgorithms.add(name);
+        } else {
+            blockedAlgorithms.delete(name);
+        }
+
+        this.transitionManager.setBlockedAlgorithms(blockedAlgorithms);
+        this.updateList();
+    }
+
+    /** Remove the modal from the DOM. */
+    destroy() {
+        this.modal.remove();
+    }
+}

--- a/src/KeyboardController.js
+++ b/src/KeyboardController.js
@@ -12,18 +12,27 @@ export default class KeyboardController {
 
     /**
      * @param {Object} deps Dependencies for keyboard shortcut handling.
-     * @param {import('./HudController.js').default}     deps.hudController - The HUD controller for displaying messages and managing UI visibility.
-     * @param {import('./TransitionManager.js').default} deps.transitionManager - The transition manager for handling algorithm changes and auto-change settings.
-     * @param {import('./MusicPlayer.js').default}       deps.musicPlayer - The music player for controlling audio playback and visibility.
-     * @param {import('./DevModeController.js').default} deps.devModeController - The dev mode controller for enabling developer features.
-     * @param {import('./Spiral.js').default}            deps.spiral - The spiral instance for controlling toggling the waveform display.
+     * @param {import('./HudController.js').default}             deps.hudController - The HUD controller for displaying messages and managing UI visibility.
+     * @param {import('./TransitionManager.js').default}         deps.transitionManager - The transition manager for handling algorithm changes and auto-change settings.
+     * @param {import('./MusicPlayer.js').default}               deps.musicPlayer - The music player for controlling audio playback and visibility.
+     * @param {import('./DevModeController.js').default}         deps.devModeController - The dev mode controller for enabling developer features.
+     * @param {import('./Spiral.js').default}                    deps.spiral - The spiral instance for controlling toggling the waveform display.
+     * @param {import('./BlockedAlgorithmsModal.js').default}    deps.blockedAlgorithmsModal - The blocked algorithms modal controller.
      */
-    constructor({ hudController, transitionManager, musicPlayer, devModeController, spiral }) {
+    constructor({
+        hudController,
+        transitionManager,
+        musicPlayer,
+        devModeController,
+        spiral,
+        blockedAlgorithmsModal,
+    }) {
         this.hudController = hudController;
         this.transitionManager = transitionManager;
         this.musicPlayer = musicPlayer;
         this.devModeController = devModeController;
         this.spiral = spiral;
+        this.blockedAlgorithmsModal = blockedAlgorithmsModal;
 
         // Dev mode shortcut should only work in development, we need to check this
         this.isDevEnvironment = globalThis.env?.isDevEnvironment;
@@ -79,6 +88,12 @@ export default class KeyboardController {
             // Toggle the help view in the HUD
             case 'KeyH': {
                 this.hudController.toggleHelpView();
+                break;
+            }
+
+            // Open / close the blocked algorithms modal
+            case 'KeyL': {
+                this.blockedAlgorithmsModal.toggleModal();
                 break;
             }
 

--- a/src/Spiral.js
+++ b/src/Spiral.js
@@ -1,10 +1,12 @@
 import AlgorithmLoader from './AlgorithmLoader.js';
+import BlockedAlgorithmsModal from './BlockedAlgorithmsModal.js';
 import DevModeController from './DevModeController.js';
 import FrequencyAnalyser from './FrequencyAnalyser.js';
 import HudController from './HudController.js';
 import KeyboardController from './KeyboardController.js';
 import MusicPlayer from './MusicPlayer.js';
 import TransitionManager from './TransitionManager.js';
+import { loadBlockedAlgorithms } from './utils/BlockedAlgorithms.js';
 import { loadPlaylist } from './utils/PlaylistStorage.js';
 import { loadPreferences, savePreference } from './utils/UserPreferences.js';
 import WaveformController from './WaveformController.js';
@@ -62,6 +64,11 @@ export default class Spiral {
         // DEV MODE CONTROLLER
         this.devModeController = new DevModeController({
             hudController: this.hud,
+            transitionManager: this.transitionManager,
+        });
+
+        // BLOCKED ALGORITHMS MODAL
+        this.blockedAlgorithmsModal = new BlockedAlgorithmsModal({
             transitionManager: this.transitionManager,
         });
 
@@ -162,6 +169,7 @@ export default class Spiral {
         this.hud.destroy();
         this.musicPlayer.destroy();
         this.devModeController.destroy();
+        this.blockedAlgorithmsModal.destroy();
         this.waveformController?.destroy();
 
         if (this.cursorHideTimeout) {
@@ -186,6 +194,10 @@ export default class Spiral {
 
         this.ctx.imageSmoothingEnabled = true;
         this.ctx.imageSmoothingQuality = 'high';
+
+        // Restore persisted blocked algorithms before the first algorithm runs
+        const blocked = loadBlockedAlgorithms();
+        this.transitionManager.blockedAlgorithms = new Set(blocked);
 
         // Apply saved user preferences before starting the timer
         const prefs = loadPreferences();
@@ -249,6 +261,7 @@ export default class Spiral {
 
         // Keyboard controller for global shortcuts
         this.keyboardController = new KeyboardController({
+            blockedAlgorithmsModal: this.blockedAlgorithmsModal,
             devModeController: this.devModeController,
             hudController: this.hud,
             musicPlayer: this.musicPlayer,

--- a/src/TransitionManager.js
+++ b/src/TransitionManager.js
@@ -1,5 +1,6 @@
 import AlgorithmLoader from './AlgorithmLoader.js';
 import { algorithms } from './generated/algorithmRegistry.js';
+import { saveBlockedAlgorithms } from './utils/BlockedAlgorithms.js';
 import { random, randomColor } from './utils/randomUtils.js';
 
 /**
@@ -14,6 +15,7 @@ export default class TransitionManager {
     algoRetries = 0;
     autoChangeIntervalInSeconds = 60;
     autoChangeTimeout = null;
+    blockedAlgorithms = new Set();
     currentAlgorithm = null;
     devModeActive = false;
     devModeAlgoA = null;
@@ -66,21 +68,47 @@ export default class TransitionManager {
     }
 
     /**
-     * Returns a random algorithm class, avoiding recently used ones. Adds the selected algorithm to the recent set and evicts the oldest if needed.
+     * Returns a random algorithm class, avoiding recently used and blocked ones.
+     * The recency capacity scales down proportionally as algorithms are blocked,
+     * so the Set never holds more entries than there are active algorithms.
      * @returns {Function} The chosen algorithm class constructor.
      */
     getRandomAlgorithm() {
-        const picks = algorithms.filter((algo) => !this.lastAlgos.has(algo));
+        const activeAlgos = algorithms.filter((algo) => !this.blockedAlgorithms.has(algo.name));
+
+        const effectiveCapacity = Math.floor(
+            activeAlgos.length * (this.lastAlgosCapacity / algorithms.length),
+        );
+
+        // Trim lastAlgos down to the effective capacity by evicting oldest entries
+        while (this.lastAlgos.size > effectiveCapacity) {
+            this.lastAlgos.delete(this.lastAlgos.values().next().value);
+        }
+
+        let picks = activeAlgos.filter((algo) => !this.lastAlgos.has(algo));
+
+        // If all active algos are in lastAlgos (only happens at very small pool sizes),
+        // reset and use the full active pool
+        if (picks.length === 0) {
+            this.lastAlgos.clear();
+            picks = activeAlgos;
+        }
 
         const randomIndex = Math.floor(Math.random() * picks.length);
         const AlgorithmClass = picks[randomIndex];
 
         this.lastAlgos.add(AlgorithmClass);
-        if (this.lastAlgos.size > this.lastAlgosCapacity) {
-            this.lastAlgos.delete(this.lastAlgos.values().next().value);
-        }
 
         return AlgorithmClass;
+    }
+
+    /**
+     * Replace the entire blocked set with a new collection of names and persist it.
+     * @param {Iterable<string>} names - Algorithm class names to block.
+     */
+    setBlockedAlgorithms(names) {
+        this.blockedAlgorithms = new Set(names);
+        saveBlockedAlgorithms([...this.blockedAlgorithms]);
     }
 
     /** Choose and instantiate a new algorithm, with retry logic for constructor errors. Respects dev mode settings. Idempotent if already transitioning. */

--- a/src/utils/BlockedAlgorithms.js
+++ b/src/utils/BlockedAlgorithms.js
@@ -1,0 +1,48 @@
+const STORAGE_KEY = 'spiral:blockedAlgorithms';
+
+/**
+ * Load the blocked algorithms list from localStorage.
+ * Returns an empty array if nothing is saved, the data is corrupt, or any
+ * entry fails validation.
+ * @returns {string[]} Array of blocked algorithm class names.
+ */
+export function loadBlockedAlgorithms() {
+    try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        if (!raw) {
+            return [];
+        }
+        const parsed = JSON.parse(raw);
+        if (!Array.isArray(parsed)) {
+            return [];
+        }
+        return parsed.filter((entry) => typeof entry === 'string');
+    } catch {
+        return [];
+    }
+}
+
+/**
+ * Persist the blocked algorithms list to localStorage.
+ * Errors are silently swallowed so storage failures never crash the app.
+ * @param {string[]} names - Algorithm class names to block.
+ */
+export function saveBlockedAlgorithms(names) {
+    try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(names));
+    } catch {
+        // localStorage unavailable or quota exceeded — fail silently
+    }
+}
+
+/**
+ * Remove the blocked algorithms list from localStorage.
+ * Errors are silently swallowed.
+ */
+export function clearBlockedAlgorithms() {
+    try {
+        localStorage.removeItem(STORAGE_KEY);
+    } catch {
+        // localStorage unavailable — fail silently
+    }
+}

--- a/style.css
+++ b/style.css
@@ -639,6 +639,117 @@ progress::-webkit-progress-value {
     z-index: 5;
 }
 
+/* BLOCKED ALGORITHMS MODAL */
+#blocked-algos-modal {
+    background: rgb(0 0 0 / 90%);
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 4;
+    font-family: var(--font-display);
+    text-align: center;
+    padding: 1.5em 2em;
+    min-width: 320px;
+    max-width: 480px;
+    width: 80vw;
+    max-height: 70vh;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75em;
+    border: 1px solid var(--color-border);
+    border-radius: 8px;
+}
+
+#blocked-algos-modal h3 {
+    margin: 0;
+    color: var(--color-accent);
+    font-size: 1.2em;
+    letter-spacing: 2px;
+}
+
+.blocked-count {
+    color: var(--color-muted);
+    font-size: 0.8em;
+    margin: 0;
+    letter-spacing: 0;
+}
+
+.blocked-search {
+    background: var(--color-bg-darker);
+    color: var(--color-text);
+    font-family: var(--font-mono);
+    font-size: 0.85em;
+    padding: 0.4em 0.6em;
+    border: 1px solid var(--color-border-light);
+    border-radius: var(--radius-md);
+    width: 100%;
+    box-sizing: border-box;
+}
+
+.blocked-search:focus {
+    border-color: var(--color-accent);
+    outline: none;
+}
+
+.blocked-list {
+    overflow-y: auto;
+    flex: 1;
+    min-height: 0;
+    text-align: left;
+    display: flex;
+    flex-direction: column;
+    gap: 0.3em;
+}
+
+.blocked-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5em;
+    font-size: 0.9em;
+    color: var(--color-text);
+    cursor: pointer;
+    padding: 0.15em 0;
+}
+
+.blocked-item input[type='checkbox'] {
+    accent-color: var(--color-accent);
+    width: 14px;
+    height: 14px;
+    cursor: pointer;
+    flex-shrink: 0;
+}
+
+.blocked-item:has(input:checked) {
+    color: var(--color-accent);
+}
+
+.blocked-item-last {
+    color: var(--color-muted);
+    cursor: not-allowed;
+}
+
+.blocked-close {
+    background: transparent;
+    color: var(--color-muted);
+    font-family: var(--font-mono);
+    font-size: 0.8em;
+    letter-spacing: 1px;
+    padding: 0.4em 1em;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    cursor: pointer;
+    transition:
+        color var(--transition-fast),
+        border-color var(--transition-fast);
+    align-self: center;
+}
+
+.blocked-close:hover {
+    color: var(--color-text);
+    border-color: var(--color-border-light);
+}
+
 @media (width <= 545px) {
     #picker {
         display: flex;


### PR DESCRIPTION
## Changes

- Press L to open a searchable, scrollable modal listing all 143 algorithms
- Checkboxes to block/unblock individual algorithms
- Blocked algorithms are never chosen by the visualizer
- At least 1 algorithm is always kept unblocked (last checkbox is disabled)
- Blocked list persists in localStorage and restores on next launch
- Recency history window (lastAlgosCapacity) scales proportionally as the active pool shrinks
- L shortcut added to the help screen and AGENTS.md

## Issue

Closes #122

## Testing

- [x] Tested in pnpm start
- [x] No console errors
- [x] Feature/fix works as expected

## Checklist

- [x] Code follows AGENTS.md conventions
- [x] CHANGELOG.md updated
- [x] Related files updated (AGENTS.md, index.html, style.css)