### PR TITLE
refactor: displayMessage toast-stack system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## 2026-03-09
 
+- refactor: displayMessage toast-stack system — multiple messages now display simultaneously in stacked lines, each with its own independent 7500ms timer; keyed messages (mode, silence, waveform, autochange, devmode) replace their previous entry rather than stacking; oldest evicted when more than 4 are queued
+
 - feat: Add blocked algorithms modal — press L to open a searchable list of all 143 algorithms with checkboxes to block/unblock them; blocked algorithms are never chosen and persist across sessions via localStorage; active pool scales the recency history window proportionally (closes #122)
 
 - feat: Save and restore user preferences across sessions — player visibility, silence mode, auto-change timing, waveform, manual/auto mode, and show-tips toggle are persisted in localStorage and restored on next launch; adds "Show welcome tips on startup" checkbox in the help screen (closes #137)

--- a/__tests__/HudController.test.js
+++ b/__tests__/HudController.test.js
@@ -23,34 +23,110 @@ describe('hudController', () => {
     });
 
     describe('displayMessage', () => {
-        it('shows the message uppercased', () => {
+        it('shows the message uppercased in a child element', () => {
             const { hud, messageElement } = createHud();
             hud.displayMessage('hello');
 
-            expect(messageElement.textContent).toBe('HELLO');
-            expect(messageElement.style.display).toBe('block');
+            const item = messageElement.querySelector('.msg-item');
+            expect(item).not.toBeNull();
+            expect(item.textContent).toBe('HELLO');
 
             hud.destroy();
         });
 
-        it('replaces a prior message', () => {
+        it('stacks messages simultaneously when no key is provided', () => {
             const { hud, messageElement } = createHud();
             hud.displayMessage('first');
             hud.displayMessage('second');
 
-            expect(messageElement.textContent).toBe('SECOND');
+            const items = messageElement.querySelectorAll('.msg-item');
+            expect(items).toHaveLength(2);
+            expect(items[0].textContent).toBe('FIRST');
+            expect(items[1].textContent).toBe('SECOND');
 
             hud.destroy();
         });
 
-        it('hides the message after 7500ms', () => {
+        it('replaces an existing message with the same key', () => {
+            const { hud, messageElement } = createHud();
+            hud.displayMessage('first', 'mode');
+            hud.displayMessage('second', 'mode');
+
+            const items = messageElement.querySelectorAll('.msg-item');
+            expect(items).toHaveLength(1);
+            expect(items[0].textContent).toBe('SECOND');
+
+            hud.destroy();
+        });
+
+        it('stacks different keyed messages independently', () => {
+            const { hud, messageElement } = createHud();
+            hud.displayMessage('manual mode', 'mode');
+            hud.displayMessage('waveform on', 'waveform');
+
+            const items = messageElement.querySelectorAll('.msg-item');
+            expect(items).toHaveLength(2);
+
+            hud.destroy();
+        });
+
+        it('evicts the oldest message when max capacity is reached', () => {
+            const { hud, messageElement } = createHud();
+            hud.displayMessage('msg1');
+            hud.displayMessage('msg2');
+            hud.displayMessage('msg3');
+            hud.displayMessage('msg4');
+            hud.displayMessage('msg5');
+
+            const items = messageElement.querySelectorAll('.msg-item');
+            expect(items).toHaveLength(4);
+            expect(items[0].textContent).toBe('MSG2');
+            expect(items[3].textContent).toBe('MSG5');
+
+            hud.destroy();
+        });
+
+        it('starts removing the message after 7500ms', () => {
             vi.useFakeTimers();
             const { hud, messageElement } = createHud();
             hud.displayMessage('hello');
             vi.advanceTimersByTime(7500);
 
-            expect(messageElement.style.display).toBe('none');
-            expect(messageElement.textContent).toBe('');
+            const item = messageElement.querySelector('.msg-item');
+            expect(item.classList.contains('msg-item-removing')).toBeTruthy();
+
+            hud.destroy();
+        });
+
+        it('removes the message from DOM after 7500ms and transition', () => {
+            vi.useFakeTimers();
+            const { hud, messageElement } = createHud();
+            hud.displayMessage('hello');
+            vi.advanceTimersByTime(7500 + 350);
+
+            expect(messageElement.querySelector('.msg-item')).toBeNull();
+
+            hud.destroy();
+        });
+
+        it('each message has its own independent timer', () => {
+            vi.useFakeTimers();
+            const { hud, messageElement } = createHud();
+
+            hud.displayMessage('first');
+            vi.advanceTimersByTime(4000);
+            hud.displayMessage('second');
+
+            // advance 3600ms more: total 7600ms
+            // first message timer fires at 7500ms ✓
+            // fallback cleanup fires at 7850ms (not yet) ✓
+            // second message timer fires at 4000 + 7500 = 11500ms (not yet) ✓
+            vi.advanceTimersByTime(3600);
+
+            const items = messageElement.querySelectorAll('.msg-item');
+            expect(items).toHaveLength(2);
+            expect(items[0].classList.contains('msg-item-removing')).toBeTruthy();
+            expect(items[1].classList.contains('msg-item-removing')).toBeFalsy();
 
             hud.destroy();
         });
@@ -143,14 +219,16 @@ describe('hudController', () => {
     });
 
     describe('destroy', () => {
-        it('cancels the pending message timer', () => {
+        it('cancels all pending message timers', () => {
             vi.useFakeTimers();
             const { hud, messageElement } = createHud();
             hud.displayMessage('test');
             hud.destroy();
             vi.advanceTimersByTime(10_000);
 
-            expect(messageElement.style.display).toBe('block');
+            const item = messageElement.querySelector('.msg-item');
+            expect(item).not.toBeNull();
+            expect(item.classList.contains('msg-item-removing')).toBeFalsy();
         });
 
         it('cancels the pending algorithm name timer', () => {

--- a/__tests__/KeyboardController.test.js
+++ b/__tests__/KeyboardController.test.js
@@ -99,7 +99,10 @@ describe('keyboardController', () => {
         dispatchKeyup('Equal');
 
         expect(transitionManager.autoChangeIntervalInSeconds).toBe(70);
-        expect(hudController.displayMessage).toHaveBeenCalledWith('Auto-change: 70secs');
+        expect(hudController.displayMessage).toHaveBeenCalledWith(
+            'Auto-change: 70secs',
+            'autochange',
+        );
 
         controller.destroy();
     });
@@ -119,7 +122,10 @@ describe('keyboardController', () => {
         dispatchKeyup('Minus');
 
         expect(transitionManager.autoChangeIntervalInSeconds).toBe(50);
-        expect(hudController.displayMessage).toHaveBeenCalledWith('Auto-change: 50secs');
+        expect(hudController.displayMessage).toHaveBeenCalledWith(
+            'Auto-change: 50secs',
+            'autochange',
+        );
 
         controller.destroy();
     });
@@ -140,7 +146,7 @@ describe('keyboardController', () => {
         dispatchKeyup('KeyA');
 
         expect(transitionManager.isInManualMode).toBeTruthy();
-        expect(hudController.displayMessage).toHaveBeenCalledWith('Manual mode');
+        expect(hudController.displayMessage).toHaveBeenCalledWith('Manual mode', 'mode');
 
         controller.destroy();
     });
@@ -151,7 +157,7 @@ describe('keyboardController', () => {
         dispatchKeyup('KeyA');
 
         expect(transitionManager.isInManualMode).toBeFalsy();
-        expect(hudController.displayMessage).toHaveBeenCalledWith('Auto mode');
+        expect(hudController.displayMessage).toHaveBeenCalledWith('Auto mode', 'mode');
 
         controller.destroy();
     });
@@ -161,13 +167,13 @@ describe('keyboardController', () => {
         dispatchKeyup('KeyS');
 
         expect(hudController.toggleSilenceMode).toHaveBeenCalledOnce();
-        expect(hudController.displayMessage).toHaveBeenCalledWith('Silent mode');
+        expect(hudController.displayMessage).toHaveBeenCalledWith('Silent mode', 'silence');
         expect(hudController.silenceMessages).toBeTruthy();
 
         dispatchKeyup('KeyS');
 
         expect(hudController.toggleSilenceMode).toHaveBeenCalledTimes(2);
-        expect(hudController.displayMessage).toHaveBeenCalledWith('Display mode');
+        expect(hudController.displayMessage).toHaveBeenCalledWith('Display mode', 'silence');
         expect(hudController.silenceMessages).toBeFalsy();
 
         controller.destroy();

--- a/__tests__/browser/DevModeController.test.js
+++ b/__tests__/browser/DevModeController.test.js
@@ -70,7 +70,10 @@ describe('devModeController (browser)', () => {
         // Badge should be visible
         expect(document.querySelector('#dev-badge').style.display).toBe('block');
         // HUD should show correct message
-        expect(deps.hudController.displayMessage).toHaveBeenLastCalledWith('DEV MODE ENABLED');
+        expect(deps.hudController.displayMessage).toHaveBeenLastCalledWith(
+            'DEV MODE ENABLED',
+            'devmode',
+        );
 
         // Disable dev mode
         checkbox.checked = false;
@@ -78,7 +81,10 @@ describe('devModeController (browser)', () => {
         // Badge should be hidden
         expect(document.querySelector('#dev-badge').style.display).toBe('none');
         // HUD should show correct message
-        expect(deps.hudController.displayMessage).toHaveBeenLastCalledWith('DEV MODE DISABLED');
+        expect(deps.hudController.displayMessage).toHaveBeenLastCalledWith(
+            'DEV MODE DISABLED',
+            'devmode',
+        );
 
         ctrl.destroy();
     });

--- a/__tests__/browser/HudController.test.js
+++ b/__tests__/browser/HudController.test.js
@@ -48,13 +48,13 @@ describe('hudController (browser smoke)', () => {
         ).toThrow('Missing required DOM element: #help');
     });
 
-    it('calls clearTimeout on both timers in destroy', () => {
+    it('calls clearTimeout on message and algorithm name timers in destroy', () => {
         const { hud } = createHud();
         const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
 
         hud.displayMessage('test');
         hud.displayAlgorithmName('algo');
-        const messageTimerId = hud.messageTimer;
+        const messageTimerId = hud.messages[0].timer;
         const algoTimerId = hud.algorithmNameTimer;
 
         hud.destroy();
@@ -63,11 +63,13 @@ describe('hudController (browser smoke)', () => {
         clearTimeoutSpy.mockRestore();
     });
 
-    it('displays a message in the real browser DOM', () => {
+    it('displays a message as a child element in the real browser DOM', () => {
         const { hud, messageElement } = createHud();
         hud.displayMessage('browser test');
-        expect(messageElement.textContent).toBe('BROWSER TEST');
-        expect(messageElement.style.display).toBe('block');
+
+        const item = messageElement.querySelector('.msg-item');
+        expect(item).not.toBeNull();
+        expect(item.textContent).toBe('BROWSER TEST');
 
         hud.destroy();
     });
@@ -86,21 +88,49 @@ describe('hudController (browser smoke)', () => {
         hud.destroy();
     });
 
-    it('properly resets timers and DOM on rapid consecutive displayMessage calls', async () => {
+    it('stacks messages simultaneously and each timer expires independently', async () => {
         const { hud, messageElement } = createHud();
         hud.messageDisplayTimeInMs = 500;
 
         hud.displayMessage('first');
-        expect(messageElement.textContent).toBe('FIRST');
+        let items = messageElement.querySelectorAll('.msg-item');
+        expect(items).toHaveLength(1);
+        expect(items[0].textContent).toBe('FIRST');
+
         await sleep(100);
         hud.displayMessage('second');
-        expect(messageElement.textContent).toBe('SECOND');
+        items = messageElement.querySelectorAll('.msg-item');
+        expect(items).toHaveLength(2);
+        expect(items[0].textContent).toBe('FIRST');
+        expect(items[1].textContent).toBe('SECOND');
+
+        // first message (added at t=0) expires at t=500ms — wait until t=510ms
+        await sleep(410);
+        expect(items[0].classList.contains('msg-item-removing')).toBeTruthy();
+        // second message (added at t=100ms) expires at t=600ms — not yet
+        expect(items[1].classList.contains('msg-item-removing')).toBeFalsy();
+
+        // wait for first message's transition to complete (350ms fallback)
         await sleep(400);
-        expect(messageElement.style.display).toBe('block');
-        expect(messageElement.textContent).toBe('SECOND');
-        await sleep(100);
-        expect(messageElement.style.display).toBe('none');
-        expect(messageElement.textContent).toBe('');
+        items = messageElement.querySelectorAll('.msg-item');
+        expect(items).toHaveLength(1);
+        expect(items[0].textContent).toBe('SECOND');
+
+        hud.destroy();
+    });
+
+    it('replaces a keyed message immediately without stacking', async () => {
+        const { hud, messageElement } = createHud();
+
+        hud.displayMessage('manual mode', 'mode');
+        expect(messageElement.querySelectorAll('.msg-item')).toHaveLength(1);
+
+        await sleep(50);
+        hud.displayMessage('auto mode', 'mode');
+
+        const items = messageElement.querySelectorAll('.msg-item');
+        expect(items).toHaveLength(1);
+        expect(items[0].textContent).toBe('AUTO MODE');
 
         hud.destroy();
     });

--- a/src/DevModeController.js
+++ b/src/DevModeController.js
@@ -152,10 +152,10 @@ export default class DevModeController {
         if (enabled) {
             this.updateDevAlgos();
             this.badge.style.display = 'block';
-            this.hudController.displayMessage('DEV MODE ENABLED');
+            this.hudController.displayMessage('DEV MODE ENABLED', 'devmode');
         } else {
             this.badge.style.display = 'none';
-            this.hudController.displayMessage('DEV MODE DISABLED');
+            this.hudController.displayMessage('DEV MODE DISABLED', 'devmode');
         }
     }
 

--- a/src/HudController.js
+++ b/src/HudController.js
@@ -7,7 +7,8 @@ export default class HudController {
     algorithmNameDisplayTimeInMs = 5000;
     algorithmNameTimer = null;
     messageDisplayTimeInMs = 7500;
-    messageTimer = null;
+    messages = [];
+    maxMessages = 4;
     showHelpView = false;
     silenceMessages = false;
 
@@ -34,7 +35,10 @@ export default class HudController {
 
     /** Clear all timers, called when the app closes. */
     destroy() {
-        clearTimeout(this.messageTimer);
+        for (const msg of this.messages) {
+            clearTimeout(msg.timer);
+        }
+        this.messages = [];
         clearTimeout(this.algorithmNameTimer);
     }
 
@@ -61,22 +65,77 @@ export default class HudController {
     }
 
     /**
-     * Show a temporary message for `this.messageDisplayTimeInMs` ms. Clears any prior message. Messages are uppercased for clarity. These messages are always shown, regardless of silent mode. Used for transient notifications like "Welcome", "Auto-change: 60secs", etc. This is called externally by various modules, such as the `KeyboardController` when adjusting auto-change settings, or the `DevModeController` when toggling Developer Mode.
+     * Show a temporary message for `this.messageDisplayTimeInMs` ms. Multiple messages stack
+     * vertically, each with its own independent timer. If `key` is provided and a message with
+     * that key is already visible, it is replaced immediately. If the stack is full
+     * (`maxMessages`), the oldest is evicted. Messages are uppercased. Always shown regardless
+     * of silent mode. Called externally by various modules for transient notifications.
      *
      * @param {string} message - The message to display.
+     * @param {string|null} [key] - Optional key: replaces an existing message with the same key.
      */
-    displayMessage(message) {
-        // clear any existing message timers to reset the display time if a new message comes in
-        clearTimeout(this.messageTimer);
+    displayMessage(message, key = null) {
+        if (key !== null) {
+            const existing = this.messages.findIndex((msg) => msg.key === key);
+            if (existing !== -1) {
+                this.evictMessage(existing);
+            }
+        }
 
-        this.messageElement.textContent = message.toUpperCase();
-        this.messageElement.style.display = 'block';
+        if (this.messages.length >= this.maxMessages) {
+            this.evictMessage(0);
+        }
 
-        // hide the message after the default display time
-        this.messageTimer = setTimeout(() => {
-            this.messageElement.style.display = 'none';
-            this.messageElement.textContent = '';
+        const element = document.createElement('div');
+        element.className = 'msg-item';
+        element.textContent = message.toUpperCase();
+        this.messageElement.append(element);
+
+        const timer = setTimeout(() => {
+            this.removeMessage(element);
         }, this.messageDisplayTimeInMs);
+
+        this.messages.push({ element, key, timer });
+    }
+
+    /**
+     * Immediately remove a message at the given index without animation.
+     * Used for keyed replacement and max-capacity eviction.
+     * @param {number} index - The index of the message to evict in the `this.messages` array.
+     */
+    evictMessage(index) {
+        const msg = this.messages[index];
+        clearTimeout(msg.timer);
+        msg.element.remove();
+        this.messages.splice(index, 1);
+    }
+
+    /**
+     * Animate a message out and remove it from the DOM and messages array after the transition.
+     * Falls back to a timeout if `transitionend` does not fire (e.g. in test environments).
+     * @param {HTMLElement} element - The message element to remove.
+     */
+    removeMessage(element) {
+        element.classList.add('msg-item-removing');
+
+        const cleanup = () => {
+            element.remove();
+            const index = this.messages.findIndex((msg) => msg.element === element);
+            if (index !== -1) {
+                this.messages.splice(index, 1);
+            }
+        };
+
+        // matches the --transition-slow duration (0.35s) used in .msg-item-removing
+        const fallback = setTimeout(cleanup, 350);
+        element.addEventListener(
+            'transitionend',
+            () => {
+                clearTimeout(fallback);
+                cleanup();
+            },
+            { once: true },
+        );
     }
 
     /**

--- a/src/KeyboardController.js
+++ b/src/KeyboardController.js
@@ -62,6 +62,7 @@ export default class KeyboardController {
                 this.transitionManager.isInManualMode = !this.transitionManager.isInManualMode;
                 this.hudController.displayMessage(
                     this.transitionManager.isInManualMode ? 'Manual mode' : 'Auto mode',
+                    'mode',
                 );
                 savePreference('isInManualMode', this.transitionManager.isInManualMode);
                 break;
@@ -115,6 +116,7 @@ export default class KeyboardController {
                 this.hudController.toggleSilenceMode();
                 this.hudController.displayMessage(
                     this.hudController.silenceMessages ? 'Silent mode' : 'Display mode',
+                    'silence',
                 );
                 savePreference('silenceMessages', this.hudController.silenceMessages);
                 break;
@@ -154,6 +156,7 @@ export default class KeyboardController {
                 );
                 this.hudController.displayMessage(
                     `Auto-change: ${this.transitionManager.autoChangeIntervalInSeconds}secs`,
+                    'autochange',
                 );
                 savePreference(
                     'autoChangeIntervalInSeconds',
@@ -171,6 +174,7 @@ export default class KeyboardController {
                 );
                 this.hudController.displayMessage(
                     `Auto-change: ${this.transitionManager.autoChangeIntervalInSeconds}secs`,
+                    'autochange',
                 );
                 savePreference(
                     'autoChangeIntervalInSeconds',

--- a/src/Spiral.js
+++ b/src/Spiral.js
@@ -313,7 +313,7 @@ export default class Spiral {
     /** Toggle the audio waveform display on or off, and show a message in the HUD indicating the new state. Called by the `KeyboardController` when the user presses the assigned shortcut key. */
     toggleWaveform() {
         const isOn = this.waveformController.toggleWaveform();
-        this.hud.displayMessage(isOn ? 'Waveform: ON' : 'Waveform: OFF');
+        this.hud.displayMessage(isOn ? 'Waveform: ON' : 'Waveform: OFF', 'waveform');
     }
 
     /**

--- a/style.css
+++ b/style.css
@@ -136,11 +136,31 @@ canvas {
 }
 
 #msg {
-    bottom: 8rem;
+    top: calc(100vh - 10rem);
     left: 50%;
     transform: translateX(-50%);
     text-align: center;
     font-size: larger;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.25rem;
+}
+
+.msg-item {
+    max-height: 2em;
+    opacity: 1;
+    overflow: hidden;
+    transition:
+        max-height var(--transition-slow) ease,
+        opacity var(--transition-slow) ease,
+        margin var(--transition-slow) ease;
+}
+
+.msg-item-removing {
+    max-height: 0;
+    opacity: 0;
+    margin: 0;
 }
 
 #help {


### PR DESCRIPTION
## Changes

- `HudController.displayMessage` now supports simultaneous stacked messages, each with its own independent 7500ms timer and smooth fade+collapse animation on expiry
- New optional `key` parameter: keyed messages replace their existing counterpart instantly rather than stacking (mode, silence, waveform, autochange, devmode)
- Max 4 simultaneous messages — oldest evicted when a 5th arrives
- `#msg` converted from a single text element to a flex container; messages render as individual `.msg-item` children
- All toggle callers updated with appropriate keys

## Issue

Closes #149

## Testing

- [x] Tested in pnpm start
- [x] No console errors
- [x] Feature/fix works as expected

## Checklist

- [x] Code follows [AGENTS.md](AGENTS.md) conventions
- [x] CHANGELOG.md updated
- [x] Related files updated (if applicable)