### PR TITLE
feat: save playlist track time on close and explicit save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 <!-- Format: ## YYYY-MM-DD followed by one-liner entries. -->
 
+## 2026-03-10
+
+- feat: Save playlist track time on close and explicit save — saves current track playback time along with playlist data; on restore, seeks to saved time but stays paused; on app close, saves current time if playlist exists (even if paused)
+
 ## 2026-03-09
 
 - refactor: displayMessage toast-stack system — multiple messages now display simultaneously in stacked lines, each with its own independent 7500ms timer; keyed messages (mode, silence, waveform, autochange, devmode) replace their previous entry rather than stacking; oldest evicted when more than 4 are queued

--- a/__tests__/Spiral.restorePlaylist.test.js
+++ b/__tests__/Spiral.restorePlaylist.test.js
@@ -68,12 +68,12 @@ describe('spiral.restorePlaylist', () => {
     it('calls restorePlaylist with resolved files and the correct index', async () => {
         localStorage.setItem(
             STORAGE_KEY,
-            JSON.stringify({ currentSongIndex: 1, tracks: SAVED_TRACKS }),
+            JSON.stringify({ currentSongIndex: 1, currentTime: 30, tracks: SAVED_TRACKS }),
         );
         const spiral = createSpiral(RESOLVED_ALL);
         await spiral.restorePlaylist();
 
-        expect(spiral.musicPlayer.restorePlaylist).toHaveBeenCalledWith(RESOLVED_ALL, 1);
+        expect(spiral.musicPlayer.restorePlaylist).toHaveBeenCalledWith(RESOLVED_ALL, 1, 30);
     });
 
     it('falls back to index 0 when the saved current track is missing after filtering', async () => {
@@ -81,12 +81,12 @@ describe('spiral.restorePlaylist', () => {
         const resolvedWithoutB = [RESOLVED_ALL[0], RESOLVED_ALL[2]];
         localStorage.setItem(
             STORAGE_KEY,
-            JSON.stringify({ currentSongIndex: 1, tracks: SAVED_TRACKS }),
+            JSON.stringify({ currentSongIndex: 1, currentTime: 0, tracks: SAVED_TRACKS }),
         );
         const spiral = createSpiral(resolvedWithoutB);
         await spiral.restorePlaylist();
 
-        expect(spiral.musicPlayer.restorePlaylist).toHaveBeenCalledWith(resolvedWithoutB, 0);
+        expect(spiral.musicPlayer.restorePlaylist).toHaveBeenCalledWith(resolvedWithoutB, 0, 0);
     });
 
     it('shows a HUD message when some tracks are missing', async () => {

--- a/__tests__/browser/MusicPlayer.test.js
+++ b/__tests__/browser/MusicPlayer.test.js
@@ -566,10 +566,7 @@ describe('musicPlayer (browser)', () => {
 
         it('restores the audio currentTime from saved time', async () => {
             const player = createPlayer();
-            vi.spyOn(player.audio, 'dispatchEvent');
-
             player.restorePlaylist(FILES, 0, 45);
-
             const event = new Event('loadedmetadata');
             player.audio.dispatchEvent(event);
 

--- a/__tests__/browser/MusicPlayer.test.js
+++ b/__tests__/browser/MusicPlayer.test.js
@@ -564,6 +564,19 @@ describe('musicPlayer (browser)', () => {
             expect(player.trackNameEl.textContent).toBe('Track B');
         });
 
+        it('restores the audio currentTime from saved time', async () => {
+            const player = createPlayer();
+            vi.spyOn(player.audio, 'dispatchEvent');
+
+            player.restorePlaylist(FILES, 0, 45);
+
+            const event = new Event('loadedmetadata');
+            player.audio.dispatchEvent(event);
+
+            await Promise.resolve();
+            expect(player.audio.currentTime).toBe(45);
+        });
+
         it('falls back to index 0 when restoreIndex is out of range', () => {
             const player = createPlayer();
             player.restorePlaylist(FILES, 99);

--- a/__tests__/utils/PlaylistStorage.test.js
+++ b/__tests__/utils/PlaylistStorage.test.js
@@ -1,6 +1,11 @@
 // @vitest-environment jsdom
 
-import { clearPlaylist, loadPlaylist, savePlaylist } from '../../src/utils/PlaylistStorage.js';
+import {
+    clearPlaylist,
+    loadPlaylist,
+    savePlaylist,
+    updatePlaylistTime,
+} from '../../src/utils/PlaylistStorage.js';
 
 const STORAGE_KEY = 'spiral:playlist';
 
@@ -22,10 +27,14 @@ describe('playlistStorage', () => {
         it('returns the saved playlist when all data is valid', () => {
             localStorage.setItem(
                 STORAGE_KEY,
-                JSON.stringify({ currentSongIndex: 1, tracks: TRACKS }),
+                JSON.stringify({ currentSongIndex: 1, currentTime: 30, tracks: TRACKS }),
             );
 
-            expect(loadPlaylist()).toStrictEqual({ currentSongIndex: 1, tracks: TRACKS });
+            expect(loadPlaylist()).toStrictEqual({
+                currentSongIndex: 1,
+                currentTime: 30,
+                tracks: TRACKS,
+            });
         });
 
         it('returns null for corrupt JSON', () => {
@@ -65,43 +74,69 @@ describe('playlistStorage', () => {
             const mixed = [...TRACKS, { trackName: 'No Path' }];
             localStorage.setItem(
                 STORAGE_KEY,
-                JSON.stringify({ currentSongIndex: 0, tracks: mixed }),
+                JSON.stringify({ currentSongIndex: 0, currentTime: 0, tracks: mixed }),
             );
 
-            expect(loadPlaylist()).toStrictEqual({ currentSongIndex: 0, tracks: TRACKS });
+            expect(loadPlaylist()).toStrictEqual({
+                currentSongIndex: 0,
+                currentTime: 0,
+                tracks: TRACKS,
+            });
         });
 
         it('filters out a track entry missing trackName and keeps the rest', () => {
             const mixed = [{ filePath: '/music/track.mp3' }, ...TRACKS];
             localStorage.setItem(
                 STORAGE_KEY,
-                JSON.stringify({ currentSongIndex: 0, tracks: mixed }),
+                JSON.stringify({ currentSongIndex: 0, currentTime: 0, tracks: mixed }),
             );
 
-            expect(loadPlaylist()).toStrictEqual({ currentSongIndex: 0, tracks: TRACKS });
+            expect(loadPlaylist()).toStrictEqual({
+                currentSongIndex: 0,
+                currentTime: 0,
+                tracks: TRACKS,
+            });
         });
 
         it('filters out a track entry with a non-string filePath and keeps the rest', () => {
             const mixed = [{ filePath: 123, trackName: 'Track' }, ...TRACKS];
             localStorage.setItem(
                 STORAGE_KEY,
-                JSON.stringify({ currentSongIndex: 0, tracks: mixed }),
+                JSON.stringify({ currentSongIndex: 0, currentTime: 0, tracks: mixed }),
             );
 
-            expect(loadPlaylist()).toStrictEqual({ currentSongIndex: 0, tracks: TRACKS });
+            expect(loadPlaylist()).toStrictEqual({
+                currentSongIndex: 0,
+                currentTime: 0,
+                tracks: TRACKS,
+            });
         });
 
         it('returns a playlist with an empty tracks array when all entries are invalid', () => {
             const bad = [{ foo: 'bar' }, null, 42];
-            localStorage.setItem(STORAGE_KEY, JSON.stringify({ currentSongIndex: 0, tracks: bad }));
+            localStorage.setItem(
+                STORAGE_KEY,
+                JSON.stringify({ currentSongIndex: 0, currentTime: 0, tracks: bad }),
+            );
 
-            expect(loadPlaylist()).toStrictEqual({ currentSongIndex: 0, tracks: [] });
+            expect(loadPlaylist()).toStrictEqual({
+                currentSongIndex: 0,
+                currentTime: 0,
+                tracks: [],
+            });
         });
 
         it('accepts an empty tracks array with index 0', () => {
-            localStorage.setItem(STORAGE_KEY, JSON.stringify({ currentSongIndex: 0, tracks: [] }));
+            localStorage.setItem(
+                STORAGE_KEY,
+                JSON.stringify({ currentSongIndex: 0, currentTime: 0, tracks: [] }),
+            );
 
-            expect(loadPlaylist()).toStrictEqual({ currentSongIndex: 0, tracks: [] });
+            expect(loadPlaylist()).toStrictEqual({
+                currentSongIndex: 0,
+                currentTime: 0,
+                tracks: [],
+            });
         });
 
         it('returns null when localStorage throws', () => {
@@ -120,7 +155,14 @@ describe('playlistStorage', () => {
             savePlaylist(TRACKS, 1);
             const stored = JSON.parse(localStorage.getItem(STORAGE_KEY));
 
-            expect(stored).toStrictEqual({ currentSongIndex: 1, tracks: TRACKS });
+            expect(stored).toStrictEqual({ currentSongIndex: 1, currentTime: 0, tracks: TRACKS });
+        });
+
+        it('persists currentTime when provided', () => {
+            savePlaylist(TRACKS, 1, 45);
+            const stored = JSON.parse(localStorage.getItem(STORAGE_KEY));
+
+            expect(stored).toStrictEqual({ currentSongIndex: 1, currentTime: 45, tracks: TRACKS });
         });
 
         it('overwrites a previously saved playlist', () => {
@@ -139,6 +181,35 @@ describe('playlistStorage', () => {
 
             expect(() => savePlaylist(TRACKS, 0)).not.toThrow();
 
+            vi.restoreAllMocks();
+        });
+    });
+
+    describe('updatePlaylistTime()', () => {
+        it('updates the currentTime of an existing saved playlist', () => {
+            savePlaylist(TRACKS, 0, 10);
+            const result = updatePlaylistTime(45);
+
+            expect(result).toBeTruthy();
+            const stored = JSON.parse(localStorage.getItem(STORAGE_KEY));
+            expect(stored).toStrictEqual({ currentSongIndex: 0, currentTime: 45, tracks: TRACKS });
+        });
+
+        it('returns false when no playlist exists', () => {
+            const result = updatePlaylistTime(30);
+
+            expect(result).toBeFalsy();
+        });
+
+        it('returns false when localStorage throws', () => {
+            savePlaylist(TRACKS, 0);
+            vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+                throw new DOMException('QuotaExceededError');
+            });
+
+            const result = updatePlaylistTime(30);
+
+            expect(result).toBeFalsy();
             vi.restoreAllMocks();
         });
     });

--- a/src/MusicPlayer.js
+++ b/src/MusicPlayer.js
@@ -407,7 +407,7 @@ export default class MusicPlayer {
      * Temporarily shows "Saved!" on the button as lightweight feedback.
      */
     handleSavePlaylist() {
-        const time = this.isPlaying ? this.audio.currentTime : 0;
+        const time = this.audio.currentTime || 0;
         const success = savePlaylist(this.tracks, this.currentSongIndex, time);
         if (success) {
             this.isDirty = false;
@@ -460,13 +460,12 @@ export default class MusicPlayer {
         // check restoreIndex bounds
         if (restoreIndex >= 0 && restoreIndex < this.trackList.length) {
             this.currentSongIndex = restoreIndex;
-            this.audio.src = this.trackList[this.currentSongIndex];
-
             const onRestoreTime = () => {
                 this.audio.currentTime = restoreTime;
                 this.audio.removeEventListener('loadedmetadata', onRestoreTime);
             };
             this.audio.addEventListener('loadedmetadata', onRestoreTime);
+            this.audio.src = this.trackList[this.currentSongIndex];
 
             this.updatePlaylistStyle();
             this.updateTrackName();

--- a/src/MusicPlayer.js
+++ b/src/MusicPlayer.js
@@ -460,12 +460,19 @@ export default class MusicPlayer {
         // check restoreIndex bounds
         if (restoreIndex >= 0 && restoreIndex < this.trackList.length) {
             this.currentSongIndex = restoreIndex;
-            const onRestoreTime = () => {
-                this.audio.currentTime = restoreTime;
-                this.audio.removeEventListener('loadedmetadata', onRestoreTime);
-            };
-            this.audio.addEventListener('loadedmetadata', onRestoreTime);
             this.audio.src = this.trackList[this.currentSongIndex];
+
+            if (restoreTime > 0) {
+                if (this.audio.readyState >= 1) {
+                    this.audio.currentTime = restoreTime;
+                } else {
+                    const onRestoreTime = () => {
+                        this.audio.currentTime = restoreTime;
+                        this.audio.removeEventListener('loadedmetadata', onRestoreTime);
+                    };
+                    this.audio.addEventListener('loadedmetadata', onRestoreTime);
+                }
+            }
 
             this.updatePlaylistStyle();
             this.updateTrackName();

--- a/src/MusicPlayer.js
+++ b/src/MusicPlayer.js
@@ -407,7 +407,8 @@ export default class MusicPlayer {
      * Temporarily shows "Saved!" on the button as lightweight feedback.
      */
     handleSavePlaylist() {
-        const success = savePlaylist(this.tracks, this.currentSongIndex);
+        const time = this.isPlaying ? this.audio.currentTime : 0;
+        const success = savePlaylist(this.tracks, this.currentSongIndex, time);
         if (success) {
             this.isDirty = false;
             this.hasSavedPlaylist = true;
@@ -448,17 +449,25 @@ export default class MusicPlayer {
      * Sets hasSavedPlaylist = true and clears the dirty flag.
      * @param {trackFiles} files - Resolved file entries.
      * @param {number} restoreIndex - Index of the track to make active; falls back to 0 if out of range.
+     * @param {number} [restoreTime] - Playback time in seconds to seek to.
      */
-    restorePlaylist(files, restoreIndex) {
+    restorePlaylist(files, restoreIndex, restoreTime = 0) {
         if (files.length === 0) {
             return;
         }
 
         this.handleFiles(files);
         // check restoreIndex bounds
-        if (restoreIndex > 0 && restoreIndex < this.trackList.length) {
+        if (restoreIndex >= 0 && restoreIndex < this.trackList.length) {
             this.currentSongIndex = restoreIndex;
             this.audio.src = this.trackList[this.currentSongIndex];
+
+            const onRestoreTime = () => {
+                this.audio.currentTime = restoreTime;
+                this.audio.removeEventListener('loadedmetadata', onRestoreTime);
+            };
+            this.audio.addEventListener('loadedmetadata', onRestoreTime);
+
             this.updatePlaylistStyle();
             this.updateTrackName();
         }

--- a/src/Spiral.js
+++ b/src/Spiral.js
@@ -8,7 +8,7 @@ import KeyboardController from './KeyboardController.js';
 import MusicPlayer from './MusicPlayer.js';
 import TransitionManager from './TransitionManager.js';
 import { loadBlockedAlgorithms } from './utils/BlockedAlgorithms.js';
-import { loadPlaylist } from './utils/PlaylistStorage.js';
+import { loadPlaylist, updatePlaylistTime } from './utils/PlaylistStorage.js';
 import { loadPreferences, savePreference } from './utils/UserPreferences.js';
 import WaveformController from './WaveformController.js';
 
@@ -177,6 +177,11 @@ export default class Spiral {
 
     /** Clean up resources before the app closes. */
     destroy() {
+        // Save playlist time if has saved playlist
+        if (this.musicPlayer?.hasSavedPlaylist) {
+            updatePlaylistTime(this.musicPlayer.audio.currentTime);
+        }
+
         // Clear welcome timers
         // oxlint-disable-next-line unicorn/no-array-for-each
         this.welcomeTimers.forEach(clearTimeout);
@@ -346,7 +351,7 @@ export default class Spiral {
 
         const savedPath = saved.tracks[saved.currentSongIndex]?.filePath;
         const newIndex = savedPath ? resolved.findIndex((file) => file.filePath === savedPath) : -1;
-        this.musicPlayer.restorePlaylist(resolved, Math.max(newIndex, 0));
+        this.musicPlayer.restorePlaylist(resolved, Math.max(newIndex, 0), saved.currentTime || 0);
     }
 
     /** Toggle the audio waveform display on or off, and show a message in the HUD indicating the new state. Called by the `KeyboardController` when the user presses the assigned shortcut key. */

--- a/src/utils/PlaylistStorage.js
+++ b/src/utils/PlaylistStorage.js
@@ -2,7 +2,7 @@ const STORAGE_KEY = 'spiral:playlist';
 
 /**
  * @typedef {{ filePath: string, trackName: string }} SavedTrack
- * @typedef {{ tracks: SavedTrack[], currentSongIndex: number }} SavedPlaylist
+ * @typedef {{ tracks: SavedTrack[], currentSongIndex: number, currentTime: number }} SavedPlaylist
  */
 
 /**
@@ -35,7 +35,9 @@ export function loadPlaylist() {
             return null;
         }
 
-        const { tracks, currentSongIndex } = /** @type {Record<string, unknown>} */ (parsed);
+        const { tracks, currentSongIndex, currentTime } = /** @type {Record<string, unknown>} */ (
+            parsed
+        );
         if (!Array.isArray(tracks)) {
             return null;
         }
@@ -46,7 +48,11 @@ export function loadPlaylist() {
 
         const validTracks = /** @type {SavedTrack[]} */ (tracks.filter((t) => isValidTrack(t)));
 
-        return { currentSongIndex: /** @type {number} */ (currentSongIndex), tracks: validTracks };
+        return {
+            currentSongIndex: /** @type {number} */ (currentSongIndex),
+            currentTime: typeof currentTime === 'number' ? currentTime : 0,
+            tracks: validTracks,
+        };
     } catch {
         return null;
     }
@@ -57,14 +63,51 @@ export function loadPlaylist() {
  * Returns true if successful, false if storage fails.
  * @param {SavedTrack[]} tracks - Track metadata to persist.
  * @param {number} currentSongIndex - Index of the currently selected track.
+ * @param {number} [currentTime] - Playback time in seconds of the current track.
  * @returns {boolean} True if save succeeded, false otherwise.
  */
-export function savePlaylist(tracks, currentSongIndex) {
+export function savePlaylist(tracks, currentSongIndex, currentTime = 0) {
     try {
-        localStorage.setItem(STORAGE_KEY, JSON.stringify({ currentSongIndex, tracks }));
+        localStorage.setItem(
+            STORAGE_KEY,
+            JSON.stringify({ currentSongIndex, currentTime, tracks }),
+        );
         return true;
     } catch {
         // localStorage unavailable or quota exceeded — fail silently
+        return false;
+    }
+}
+
+/**
+ * Update just the currentTime field of an already-saved playlist.
+ * Returns true if successful, false if storage fails or no playlist exists.
+ * @param {number} currentTime - Playback time in seconds to save.
+ * @returns {boolean} True if update succeeded, false otherwise.
+ */
+export function updatePlaylistTime(currentTime) {
+    try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        if (!raw) {
+            return false;
+        }
+
+        const parsed = JSON.parse(raw);
+        if (!parsed || typeof parsed !== 'object') {
+            return false;
+        }
+
+        const { tracks, currentSongIndex } = /** @type {Record<string, unknown>} */ (parsed);
+        if (!Array.isArray(tracks) || !Number.isInteger(currentSongIndex)) {
+            return false;
+        }
+
+        localStorage.setItem(
+            STORAGE_KEY,
+            JSON.stringify({ currentSongIndex, currentTime, tracks }),
+        );
+        return true;
+    } catch {
         return false;
     }
 }


### PR DESCRIPTION
- Add `currentTime` field to saved playlist data
- Update `savePlaylist()` to accept optional `currentTime` parameter
- Add `updatePlaylistTime()` function to update just the time field of an existing saved playlist
- On explicit save: saves current time if playing, 0 if paused
- On app close: saves current time if playlist exists (even if paused)
- On restore: seeks to saved time but stays paused
- Add tests for the new functionality
## Issue
Closes #155

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Playlists now save and restore the current playback position (including when paused) on explicit save or app close, and resume playback at that time after reopening.
  * Restoration now seeks to the saved time once track metadata is ready, preserving progress even if tracks shift during restore.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->