### PR TITLE
fix: update silent mode behavior to preserve algorithm name and adjust display logic

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -19,7 +19,7 @@
         ],
         "eslint/max-lines-per-function": ["warn", 250],
         "eslint/max-statements": ["warn", 52],
-        "eslint/max-lines": ["warn", 285],
+        "eslint/max-lines": ["warn", 300],
         "eslint/max-params": ["warn", 5],
         "eslint/max-classes-per-file": ["warn", 6],
         "eslint/no-console": "warn",

--- a/__tests__/HudController.test.js
+++ b/__tests__/HudController.test.js
@@ -17,6 +17,7 @@ function createHud() {
     };
 }
 
+// oxlint-disable-next-line max-lines-per-function
 describe('hudController', () => {
     afterEach(() => {
         vi.useRealTimers();
@@ -141,12 +142,13 @@ describe('hudController', () => {
             hud.destroy();
         });
 
-        it('does nothing when silent mode is active', () => {
+        it('still stores the name in silent mode but keeps element hidden', () => {
             const { hud, algosDisplayElement } = createHud();
             hud.toggleSilenceMode();
             hud.displayAlgorithmName('myAlgo');
 
-            expect(algosDisplayElement.textContent).toBe('');
+            expect(algosDisplayElement.textContent).toBe('MYALGO');
+            expect(algosDisplayElement.style.display).toBe('none');
 
             hud.destroy();
         });
@@ -184,13 +186,36 @@ describe('hudController', () => {
             hud.destroy();
         });
 
-        it('clears algos display on activation', () => {
+        it('hides element on activation but preserves pending name', () => {
             const { hud, algosDisplayElement } = createHud();
             hud.displayAlgorithmName('test');
             hud.toggleSilenceMode();
 
-            expect(algosDisplayElement.textContent).toBe('');
+            expect(algosDisplayElement.textContent).toBe('TEST');
             expect(algosDisplayElement.style.display).toBe('none');
+
+            hud.destroy();
+        });
+
+        it('reveals pending name when toggled off', () => {
+            const { hud, algosDisplayElement } = createHud();
+            hud.toggleSilenceMode();
+            hud.displayAlgorithmName('myAlgo');
+            hud.toggleSilenceMode();
+
+            expect(algosDisplayElement.textContent).toBe('MYALGO');
+            expect(algosDisplayElement.style.display).toBe('block');
+
+            hud.destroy();
+        });
+
+        it('does not show element when toggled off with no pending name', () => {
+            const { hud, algosDisplayElement } = createHud();
+            hud.toggleSilenceMode();
+            hud.toggleSilenceMode();
+
+            expect(algosDisplayElement.textContent).toBe('');
+            expect(algosDisplayElement.style.display).not.toBe('block');
 
             hud.destroy();
         });

--- a/src/HudController.js
+++ b/src/HudController.js
@@ -55,15 +55,16 @@ export default class HudController {
      * @param {string} name - The algorithm name to display.
      */
     displayAlgorithmName(name) {
-        if (this.silenceMessages) {
-            return;
-        }
-
         // clear any existing timers to reset the display time if a new algorithm name comes in before the prior one is hidden
         clearTimeout(this.algorithmNameTimer);
 
         this.algosDisplayElement.textContent = `${name.toUpperCase()}`;
-        this.algosDisplayElement.style.display = 'block';
+
+        // only show the element if not in silent mode; the name is still stored so
+        // toggling off silent mode can reveal it
+        if (!this.silenceMessages) {
+            this.algosDisplayElement.style.display = 'block';
+        }
 
         // hide the algorithm name after the default display time
         this.algorithmNameTimer = setTimeout(() => {
@@ -159,7 +160,16 @@ export default class HudController {
      */
     toggleSilenceMode() {
         this.silenceMessages = !this.silenceMessages;
-        this.algosDisplayElement.textContent = '';
-        this.algosDisplayElement.style.display = 'none';
+
+        if (this.silenceMessages) {
+            // entering silent mode: hide the element but keep textContent so it
+            // can be revealed if the user exits silent mode while the timer is still running
+            this.algosDisplayElement.style.display = 'none';
+        } else {
+            // exiting silent mode: reveal the element if there is a pending name
+            if (this.algosDisplayElement.textContent !== '') {
+                this.algosDisplayElement.style.display = 'block';
+            }
+        }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Algorithm names are now preserved when silent mode is toggled, allowing pending names to display when silent mode is turned off.

* **Tests**
  * Updated test suite to verify pending algorithm name storage and visibility toggling behavior.

* **Chores**
  * Updated linter configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->